### PR TITLE
정산 시스템 추가 (Kurly, Coupang, 편집용)

### DIFF
--- a/database/settlements.sql
+++ b/database/settlements.sql
@@ -1,0 +1,98 @@
+-- Settlement system tables
+
+-- Common settlement table
+CREATE TABLE settlements (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  settlement_date DATE NOT NULL,
+  settlement_type TEXT NOT NULL CHECK (settlement_type IN ('kurly', 'coupang', 'general')),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  created_by UUID REFERENCES auth.users(id)
+);
+
+-- Kurly settlement details
+CREATE TABLE kurly_settlements (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  settlement_id UUID REFERENCES settlements(id) ON DELETE CASCADE NOT NULL,
+  company_name TEXT NOT NULL,
+  support_type TEXT,
+  amount DECIMAL(12, 2) NOT NULL,
+  note TEXT,
+  settlement_amount DECIMAL(12, 2) NOT NULL,
+  supply_price DECIMAL(12, 2) NOT NULL,
+  delivery_count INT,
+  unit_price DECIMAL(10, 2),
+  center TEXT,
+  region TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Coupang settlement details
+CREATE TABLE coupang_settlements (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  settlement_id UUID REFERENCES settlements(id) ON DELETE CASCADE NOT NULL,
+  settlement_date DATE NOT NULL,
+  day_or_night TEXT CHECK (day_or_night IN ('day', 'night')),
+  delivery_area TEXT,
+  courier_name TEXT NOT NULL,
+  delivery_count INT NOT NULL,
+  unit_price DECIMAL(10, 2) NOT NULL,
+  supply_price DECIMAL(12, 2) NOT NULL,
+  vat DECIMAL(12, 2) NOT NULL,
+  total_amount DECIMAL(12, 2) NOT NULL,
+  profit DECIMAL(12, 2) NOT NULL,
+  invoice_status TEXT,
+  payment_type TEXT,
+  note TEXT,
+  transaction_partner TEXT,
+  return_count INT,
+  camp TEXT,
+  route_id TEXT,
+  pdd TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- General settlement details (for the editable version)
+CREATE TABLE general_settlements (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  settlement_id UUID REFERENCES settlements(id) ON DELETE CASCADE NOT NULL,
+  row_order INT NOT NULL,
+  column_name TEXT NOT NULL,
+  column_value TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- RLS Policies for settlement tables
+ALTER TABLE settlements ENABLE ROW LEVEL SECURITY;
+ALTER TABLE kurly_settlements ENABLE ROW LEVEL SECURITY;
+ALTER TABLE coupang_settlements ENABLE ROW LEVEL SECURITY;
+ALTER TABLE general_settlements ENABLE ROW LEVEL SECURITY;
+
+-- Admins can do everything
+CREATE POLICY "Admins can do everything on settlements" ON settlements 
+  FOR ALL USING (auth.jwt() -> 'app_metadata' ->> 'role' = 'admin');
+
+CREATE POLICY "Admins can do everything on kurly_settlements" ON kurly_settlements
+  FOR ALL USING (auth.jwt() -> 'app_metadata' ->> 'role' = 'admin');
+
+CREATE POLICY "Admins can do everything on coupang_settlements" ON coupang_settlements
+  FOR ALL USING (auth.jwt() -> 'app_metadata' ->> 'role' = 'admin');
+
+CREATE POLICY "Admins can do everything on general_settlements" ON general_settlements
+  FOR ALL USING (auth.jwt() -> 'app_metadata' ->> 'role' = 'admin');
+
+-- Regular users can only view
+CREATE POLICY "Regular users can view settlements" ON settlements 
+  FOR SELECT USING (auth.jwt() -> 'app_metadata' ->> 'role' = 'courier');
+
+CREATE POLICY "Regular users can view kurly_settlements" ON kurly_settlements
+  FOR SELECT USING (auth.jwt() -> 'app_metadata' ->> 'role' = 'courier');
+
+CREATE POLICY "Regular users can view coupang_settlements" ON coupang_settlements
+  FOR SELECT USING (auth.jwt() -> 'app_metadata' ->> 'role' = 'courier');
+
+CREATE POLICY "Regular users can view general_settlements" ON general_settlements
+  FOR SELECT USING (auth.jwt() -> 'app_metadata' ->> 'role' = 'courier');

--- a/src/app/dashboard/settlements/[id]/page.tsx
+++ b/src/app/dashboard/settlements/[id]/page.tsx
@@ -1,0 +1,234 @@
+import React from 'react';
+import { redirect } from 'next/navigation';
+import { 
+  getSettlementById, 
+  getKurlySettlements, 
+  getCoupangSettlements, 
+  getGeneralSettlementColumns
+} from '@/lib/settlements';
+import Link from 'next/link';
+
+export const dynamic = 'force-dynamic';
+
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+};
+
+const formatCurrency = (amount: number) => {
+  return new Intl.NumberFormat('ko-KR', {
+    style: 'currency',
+    currency: 'KRW',
+    minimumFractionDigits: 0,
+  }).format(amount);
+};
+
+export default async function ViewSettlementPage({
+  params
+}: {
+  params: { id: string }
+}) {
+  const { id } = params;
+  
+  try {
+    const settlement = await getSettlementById(id);
+    const type = settlement.settlement_type;
+    
+    let content = null;
+    
+    if (type === 'kurly') {
+      const kurlySettlements = await getKurlySettlements(id);
+      
+      if (kurlySettlements.length > 0) {
+        const data = kurlySettlements[0];
+        
+        content = (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="border-b p-3">
+              <span className="font-bold">업체명:</span> {data.company_name}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">날짜:</span> {formatDate(settlement.settlement_date)}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">지원/대처:</span> {data.support_type || '-'}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">금액(만원):</span> {data.amount ? formatCurrency(data.amount * 10000) : '-'}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">정산금액:</span> {formatCurrency(data.settlement_amount)}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">공급가:</span> {formatCurrency(data.supply_price)}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">딜리건수:</span> {data.delivery_count || '-'}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">단가:</span> {data.unit_price ? formatCurrency(data.unit_price) : '-'}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">센터:</span> {data.center || '-'}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">지역:</span> {data.region || '-'}
+            </div>
+            <div className="col-span-2 border-b p-3">
+              <span className="font-bold">비고:</span> {data.note || '-'}
+            </div>
+          </div>
+        );
+      }
+    } else if (type === 'coupang') {
+      const coupangSettlements = await getCoupangSettlements(id);
+      
+      if (coupangSettlements.length > 0) {
+        const data = coupangSettlements[0];
+        
+        content = (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="border-b p-3">
+              <span className="font-bold">날짜:</span> {formatDate(data.settlement_date)}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">주/야:</span> {data.day_or_night === 'day' ? '주간' : '야간'}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">배송구역:</span> {data.delivery_area || '-'}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">이름:</span> {data.courier_name}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">건수:</span> {data.delivery_count}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">단가(VAT별도):</span> {formatCurrency(data.unit_price)}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">공급가:</span> {formatCurrency(data.supply_price)}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">부가세:</span> {formatCurrency(data.vat)}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">합계:</span> {formatCurrency(data.total_amount)}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">수익금:</span> {formatCurrency(data.profit)}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">계산서:</span> {data.invoice_status || '-'}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">입금형태:</span> {data.payment_type || '-'}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">거래처(입금처):</span> {data.transaction_partner || '-'}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">반품건수:</span> {data.return_count || '0'}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">캠프:</span> {data.camp || '-'}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">라우트:</span> {data.route_id || '-'}
+            </div>
+            <div className="border-b p-3">
+              <span className="font-bold">PDD:</span> {data.pdd || '-'}
+            </div>
+            <div className="col-span-3 border-b p-3">
+              <span className="font-bold">비고:</span> {data.note || '-'}
+            </div>
+          </div>
+        );
+      }
+    } else if (type === 'general') {
+      const { columns, rows } = await getGeneralSettlementColumns(id);
+      
+      if (columns.length > 0 && rows.length > 0) {
+        content = (
+          <div className="overflow-x-auto">
+            <table className="min-w-full border border-gray-300">
+              <thead>
+                <tr className="bg-gray-100">
+                  {columns.map((column, index) => (
+                    <th key={index} className="border p-2 text-left">
+                      {column}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row, rowIndex) => (
+                  <tr key={rowIndex} className={rowIndex % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+                    {columns.map((column, colIndex) => (
+                      <td key={colIndex} className="border p-2">
+                        {row[column]?.toString() || ''}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        );
+      }
+    }
+
+    // Title based on settlement type
+    const getTitle = () => {
+      switch (type) {
+        case 'kurly':
+          return '컬리 정산 상세';
+        case 'coupang':
+          return '쿠팡 정산 상세';
+        case 'general':
+          return '편집용 정산 상세';
+        default:
+          return '정산 상세';
+      }
+    };
+
+    return (
+      <div className="container mx-auto p-4">
+        <div className="mb-6 flex justify-between items-center">
+          <h1 className="text-2xl font-bold">{getTitle()}</h1>
+          <div className="space-x-2">
+            <Link
+              href={`/dashboard/settlements/edit/${id}`}
+              className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+            >
+              수정
+            </Link>
+            <Link
+              href="/dashboard/settlements"
+              className="px-4 py-2 bg-gray-500 text-white rounded hover:bg-gray-600"
+            >
+              목록으로 돌아가기
+            </Link>
+          </div>
+        </div>
+
+        <div className="bg-white shadow-md rounded-lg p-6">
+          {content ? (
+            content
+          ) : (
+            <div className="text-center p-6">
+              <p className="text-red-500">정산 데이터를 불러올 수 없습니다.</p>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  } catch (error) {
+    console.error('Failed to load settlement:', error);
+    redirect('/dashboard/settlements');
+  }
+}

--- a/src/app/dashboard/settlements/edit/[id]/page.tsx
+++ b/src/app/dashboard/settlements/edit/[id]/page.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { redirect } from 'next/navigation';
+import { 
+  getSettlementById, 
+  getKurlySettlements, 
+  getCoupangSettlements, 
+  getGeneralSettlementColumns,
+  updateSettlement,
+  updateKurlySettlement,
+  updateCoupangSettlement,
+  updateGeneralSettlement
+} from '@/lib/settlements';
+import KurlySettlementForm from '@/components/settlements/KurlySettlementForm';
+import CoupangSettlementForm from '@/components/settlements/CoupangSettlementForm';
+import GeneralSettlementForm from '@/components/settlements/GeneralSettlementForm';
+import Link from 'next/link';
+import { 
+  CreateKurlySettlementDTO, 
+  CreateCoupangSettlementDTO, 
+  CreateGeneralSettlementDTO 
+} from '@/lib/types/settlement';
+
+export const dynamic = 'force-dynamic';
+
+export default async function EditSettlementPage({
+  params
+}: {
+  params: { id: string }
+}) {
+  const { id } = params;
+  
+  try {
+    const settlement = await getSettlementById(id);
+    const type = settlement.settlement_type;
+    
+    // Prepare data based on settlement type
+    let initialData: any = null;
+    
+    if (type === 'kurly') {
+      const kurlySettlements = await getKurlySettlements(id);
+      if (kurlySettlements.length > 0) {
+        initialData = kurlySettlements[0];
+      }
+    } else if (type === 'coupang') {
+      const coupangSettlements = await getCoupangSettlements(id);
+      if (coupangSettlements.length > 0) {
+        initialData = coupangSettlements[0];
+      }
+    } else if (type === 'general') {
+      initialData = await getGeneralSettlementColumns(id);
+    }
+    
+    // Server actions for form submissions
+    const handleUpdateKurlySettlement = async (data: CreateKurlySettlementDTO) => {
+      'use server';
+      try {
+        // Update the settlement date
+        await updateSettlement(id, data.settlement_date);
+        
+        // Update the kurly settlement details
+        if (initialData && initialData.id) {
+          await updateKurlySettlement(initialData.id, data);
+        }
+        
+        // Redirect to the settlements page
+        redirect('/dashboard/settlements');
+      } catch (error) {
+        console.error('Failed to update Kurly settlement:', error);
+        throw error;
+      }
+    };
+    
+    const handleUpdateCoupangSettlement = async (data: CreateCoupangSettlementDTO) => {
+      'use server';
+      try {
+        // Update the settlement date
+        await updateSettlement(id, data.settlement_date);
+        
+        // Update the coupang settlement details
+        if (initialData && initialData.id) {
+          await updateCoupangSettlement(initialData.id, data);
+        }
+        
+        // Redirect to the settlements page
+        redirect('/dashboard/settlements');
+      } catch (error) {
+        console.error('Failed to update Coupang settlement:', error);
+        throw error;
+      }
+    };
+    
+    const handleUpdateGeneralSettlement = async (data: CreateGeneralSettlementDTO) => {
+      'use server';
+      try {
+        // General settlements don't have a specific date, so we keep the existing one
+        
+        // Update the general settlement details
+        await updateGeneralSettlement(id, data);
+        
+        // Redirect to the settlements page
+        redirect('/dashboard/settlements');
+      } catch (error) {
+        console.error('Failed to update General settlement:', error);
+        throw error;
+      }
+    };
+
+    // Title based on settlement type
+    const getTitle = () => {
+      switch (type) {
+        case 'kurly':
+          return '컬리 정산 수정';
+        case 'coupang':
+          return '쿠팡 정산 수정';
+        case 'general':
+          return '편집용 정산 수정';
+        default:
+          return '정산 수정';
+      }
+    };
+
+    return (
+      <div className="container mx-auto p-4">
+        <div className="mb-6 flex justify-between items-center">
+          <h1 className="text-2xl font-bold">{getTitle()}</h1>
+          <div>
+            <Link
+              href="/dashboard/settlements"
+              className="px-4 py-2 bg-gray-500 text-white rounded hover:bg-gray-600"
+            >
+              목록으로 돌아가기
+            </Link>
+          </div>
+        </div>
+
+        <div className="bg-white shadow-md rounded-lg p-6">
+          {type === 'kurly' && initialData && (
+            <KurlySettlementForm 
+              initialData={initialData}
+              onSubmit={handleUpdateKurlySettlement} 
+              onCancel={() => redirect('/dashboard/settlements')} 
+            />
+          )}
+          
+          {type === 'coupang' && initialData && (
+            <CoupangSettlementForm 
+              initialData={initialData}
+              onSubmit={handleUpdateCoupangSettlement} 
+              onCancel={() => redirect('/dashboard/settlements')} 
+            />
+          )}
+          
+          {type === 'general' && initialData && (
+            <GeneralSettlementForm 
+              initialData={initialData}
+              onSubmit={handleUpdateGeneralSettlement} 
+              onCancel={() => redirect('/dashboard/settlements')} 
+            />
+          )}
+          
+          {!initialData && (
+            <div className="text-center p-6">
+              <p className="text-red-500">정산 데이터를 불러올 수 없습니다.</p>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  } catch (error) {
+    console.error('Failed to load settlement:', error);
+    redirect('/dashboard/settlements');
+  }
+}

--- a/src/app/dashboard/settlements/new/page.tsx
+++ b/src/app/dashboard/settlements/new/page.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { redirect } from 'next/navigation';
+import { createSettlement, createKurlySettlement, createCoupangSettlement, createGeneralSettlement } from '@/lib/settlements';
+import KurlySettlementForm from '@/components/settlements/KurlySettlementForm';
+import CoupangSettlementForm from '@/components/settlements/CoupangSettlementForm';
+import GeneralSettlementForm from '@/components/settlements/GeneralSettlementForm';
+import Link from 'next/link';
+import { CreateKurlySettlementDTO, CreateCoupangSettlementDTO, CreateGeneralSettlementDTO } from '@/lib/types/settlement';
+
+export default function NewSettlementPage({
+  searchParams,
+}: {
+  searchParams: { [key: string]: string | string[] | undefined };
+}) {
+  const type = searchParams.type as string || 'kurly';
+  
+  // Server actions for form submissions
+  const handleCreateKurlySettlement = async (data: CreateKurlySettlementDTO) => {
+    'use server';
+    try {
+      // First create the settlement record
+      const settlement = await createSettlement(data.settlement_date, 'kurly');
+      
+      // Then create the kurly settlement details
+      await createKurlySettlement(settlement.id, data);
+      
+      // Redirect to the settlements page
+      redirect('/dashboard/settlements');
+    } catch (error) {
+      console.error('Failed to create Kurly settlement:', error);
+      throw error;
+    }
+  };
+  
+  const handleCreateCoupangSettlement = async (data: CreateCoupangSettlementDTO) => {
+    'use server';
+    try {
+      // First create the settlement record
+      const settlement = await createSettlement(data.settlement_date, 'coupang');
+      
+      // Then create the coupang settlement details
+      await createCoupangSettlement(settlement.id, data);
+      
+      // Redirect to the settlements page
+      redirect('/dashboard/settlements');
+    } catch (error) {
+      console.error('Failed to create Coupang settlement:', error);
+      throw error;
+    }
+  };
+  
+  const handleCreateGeneralSettlement = async (data: CreateGeneralSettlementDTO) => {
+    'use server';
+    try {
+      // First create the settlement record
+      const today = new Date().toISOString().split('T')[0];
+      const settlement = await createSettlement(today, 'general');
+      
+      // Then create the general settlement details
+      await createGeneralSettlement(settlement.id, data);
+      
+      // Redirect to the settlements page
+      redirect('/dashboard/settlements');
+    } catch (error) {
+      console.error('Failed to create General settlement:', error);
+      throw error;
+    }
+  };
+
+  // Title based on settlement type
+  const getTitle = () => {
+    switch (type) {
+      case 'kurly':
+        return '컬리 정산 추가';
+      case 'coupang':
+        return '쿠팡 정산 추가';
+      case 'general':
+        return '편집용 정산 추가';
+      default:
+        return '정산 추가';
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-4">
+      <div className="mb-6 flex justify-between items-center">
+        <h1 className="text-2xl font-bold">{getTitle()}</h1>
+        <div>
+          <Link
+            href="/dashboard/settlements"
+            className="px-4 py-2 bg-gray-500 text-white rounded hover:bg-gray-600"
+          >
+            목록으로 돌아가기
+          </Link>
+        </div>
+      </div>
+
+      <div className="bg-white shadow-md rounded-lg p-6">
+        {type === 'kurly' && (
+          <KurlySettlementForm 
+            onSubmit={handleCreateKurlySettlement} 
+            onCancel={() => redirect('/dashboard/settlements')} 
+          />
+        )}
+        
+        {type === 'coupang' && (
+          <CoupangSettlementForm 
+            onSubmit={handleCreateCoupangSettlement} 
+            onCancel={() => redirect('/dashboard/settlements')} 
+          />
+        )}
+        
+        {type === 'general' && (
+          <GeneralSettlementForm 
+            onSubmit={handleCreateGeneralSettlement} 
+            onCancel={() => redirect('/dashboard/settlements')} 
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/settlements/page.tsx
+++ b/src/app/dashboard/settlements/page.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { getSettlements, deleteSettlement } from '@/lib/settlements';
+import SettlementList from '@/components/settlements/SettlementList';
+import Link from 'next/link';
+import { Settlement } from '@/lib/types/settlement';
+
+export const dynamic = 'force-dynamic';
+
+export default async function SettlementsPage() {
+  let settlements: Settlement[] = [];
+  let error = null;
+
+  try {
+    settlements = await getSettlements();
+  } catch (err) {
+    error = err instanceof Error ? err.message : '정산 데이터를 불러오는 중 오류가 발생했습니다.';
+  }
+
+  const handleDeleteSettlement = async (id: string) => {
+    'use server';
+    try {
+      await deleteSettlement(id);
+    } catch (error) {
+      console.error('Failed to delete settlement:', error);
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-4">
+      <div className="mb-6 flex justify-between items-center">
+        <h1 className="text-2xl font-bold">정산 관리</h1>
+        <div className="space-x-2">
+          <Link
+            href="/dashboard/settlements/new?type=kurly"
+            className="inline-block px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600"
+          >
+            컬리 정산 추가
+          </Link>
+          <Link
+            href="/dashboard/settlements/new?type=coupang"
+            className="inline-block px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+          >
+            쿠팡 정산 추가
+          </Link>
+          <Link
+            href="/dashboard/settlements/new?type=general"
+            className="inline-block px-4 py-2 bg-purple-500 text-white rounded hover:bg-purple-600"
+          >
+            편집용 정산 추가
+          </Link>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4">
+          {error}
+        </div>
+      ) : (
+        <div className="bg-white shadow-md rounded-lg">
+          <SettlementList
+            settlements={settlements}
+            onDeleteSettlement={handleDeleteSettlement}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+interface SidebarLinkProps {
+  href: string;
+  icon: React.ReactNode;
+  label: string;
+  active: boolean;
+}
+
+const SidebarLink: React.FC<SidebarLinkProps> = ({ href, icon, label, active }) => {
+  return (
+    <Link
+      href={href}
+      className={`flex items-center p-2 rounded-md ${
+        active
+          ? 'bg-blue-100 text-blue-600'
+          : 'text-gray-700 hover:bg-gray-100'
+      }`}
+    >
+      <div className="mr-3">{icon}</div>
+      <span>{label}</span>
+    </Link>
+  );
+};
+
+export default function Sidebar() {
+  const pathname = usePathname();
+
+  const isActive = (path: string) => {
+    return pathname === path || pathname?.startsWith(`${path}/`);
+  };
+
+  return (
+    <aside className="w-64 bg-white border-r border-gray-200 p-4 hidden md:block">
+      <div className="mb-6">
+        <h3 className="text-lg font-semibold">물류 배치 관리</h3>
+      </div>
+      <nav className="space-y-1">
+        <SidebarLink
+          href="/dashboard"
+          icon={<span className="text-xl">📊</span>}
+          label="홈"
+          active={isActive('/dashboard')}
+        />
+        <SidebarLink
+          href="/dashboard/assignments"
+          icon={<span className="text-xl">📦</span>}
+          label="배치 관리"
+          active={isActive('/dashboard/assignments')}
+        />
+        <SidebarLink
+          href="/dashboard/logistics-centers"
+          icon={<span className="text-xl">🏢</span>}
+          label="물류센터 관리"
+          active={isActive('/dashboard/logistics-centers')}
+        />
+        <SidebarLink
+          href="/dashboard/couriers"
+          icon={<span className="text-xl">🚚</span>}
+          label="기사 관리"
+          active={isActive('/dashboard/couriers')}
+        />
+        <SidebarLink
+          href="/dashboard/votes"
+          icon={<span className="text-xl">📝</span>}
+          label="투표 관리"
+          active={isActive('/dashboard/votes')}
+        />
+        <SidebarLink
+          href="/dashboard/statistics"
+          icon={<span className="text-xl">📈</span>}
+          label="통계"
+          active={isActive('/dashboard/statistics')}
+        />
+        
+        {/* New settlement section */}
+        <div className="pt-4 mt-4 border-t border-gray-200">
+          <h3 className="text-lg font-semibold mb-2">정산 관리</h3>
+          <SidebarLink
+            href="/dashboard/settlements"
+            icon={<span className="text-xl">💰</span>}
+            label="전체 정산"
+            active={isActive('/dashboard/settlements')}
+          />
+          <SidebarLink
+            href="/dashboard/settlements/new?type=kurly"
+            icon={<span className="text-xl">🛒</span>}
+            label="컬리 정산 추가"
+            active={pathname === '/dashboard/settlements/new' && pathname.includes('type=kurly')}
+          />
+          <SidebarLink
+            href="/dashboard/settlements/new?type=coupang"
+            icon={<span className="text-xl">📦</span>}
+            label="쿠팡 정산 추가"
+            active={pathname === '/dashboard/settlements/new' && pathname.includes('type=coupang')}
+          />
+          <SidebarLink
+            href="/dashboard/settlements/new?type=general"
+            icon={<span className="text-xl">📑</span>}
+            label="편집용 정산 추가"
+            active={pathname === '/dashboard/settlements/new' && pathname.includes('type=general')}
+          />
+        </div>
+      </nav>
+    </aside>
+  );
+}

--- a/src/components/settlements/CoupangSettlementForm.tsx
+++ b/src/components/settlements/CoupangSettlementForm.tsx
@@ -1,0 +1,391 @@
+import React, { useState, useEffect } from 'react';
+import { CoupangSettlement, CreateCoupangSettlementDTO } from '@/lib/types/settlement';
+
+interface CoupangSettlementFormProps {
+  initialData?: CoupangSettlement;
+  onSubmit: (data: CreateCoupangSettlementDTO) => void;
+  onCancel: () => void;
+}
+
+const CoupangSettlementForm: React.FC<CoupangSettlementFormProps> = ({
+  initialData,
+  onSubmit,
+  onCancel,
+}) => {
+  const [formData, setFormData] = useState<CreateCoupangSettlementDTO>({
+    settlement_date: new Date().toISOString().split('T')[0],
+    day_or_night: 'day',
+    delivery_area: '',
+    courier_name: '',
+    delivery_count: 0,
+    unit_price: 0,
+    supply_price: 0,
+    vat: 0,
+    total_amount: 0,
+    profit: 0,
+    invoice_status: '',
+    payment_type: '',
+    note: '',
+    transaction_partner: '',
+    return_count: 0,
+    camp: '',
+    route_id: '',
+    pdd: '',
+  });
+
+  // Auto-calculate values when dependencies change
+  useEffect(() => {
+    if (formData.unit_price && formData.delivery_count) {
+      const supply = formData.unit_price * formData.delivery_count;
+      const vat = Math.round(supply * 0.1);
+      
+      setFormData(prev => ({
+        ...prev,
+        supply_price: supply,
+        vat: vat,
+        total_amount: supply + vat
+      }));
+    }
+  }, [formData.unit_price, formData.delivery_count]);
+
+  useEffect(() => {
+    if (initialData) {
+      setFormData({
+        settlement_date: initialData.settlement_date,
+        day_or_night: initialData.day_or_night || 'day',
+        delivery_area: initialData.delivery_area || '',
+        courier_name: initialData.courier_name,
+        delivery_count: initialData.delivery_count,
+        unit_price: initialData.unit_price,
+        supply_price: initialData.supply_price,
+        vat: initialData.vat,
+        total_amount: initialData.total_amount,
+        profit: initialData.profit,
+        invoice_status: initialData.invoice_status || '',
+        payment_type: initialData.payment_type || '',
+        note: initialData.note || '',
+        transaction_partner: initialData.transaction_partner || '',
+        return_count: initialData.return_count || 0,
+        camp: initialData.camp || '',
+        route_id: initialData.route_id || '',
+        pdd: initialData.pdd || '',
+      });
+    }
+  }, [initialData]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    
+    // Handle numeric fields
+    if ([
+      'delivery_count', 
+      'unit_price', 
+      'supply_price', 
+      'vat', 
+      'total_amount', 
+      'profit',
+      'return_count'
+    ].includes(name)) {
+      setFormData({
+        ...formData,
+        [name]: parseFloat(value) || 0,
+      });
+    } else {
+      setFormData({
+        ...formData,
+        [name]: value,
+      });
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit(formData);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div>
+          <label htmlFor="settlement_date" className="block text-sm font-medium text-gray-700">
+            날짜
+          </label>
+          <input
+            type="date"
+            id="settlement_date"
+            name="settlement_date"
+            value={formData.settlement_date}
+            onChange={handleChange}
+            required
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="day_or_night" className="block text-sm font-medium text-gray-700">
+            주/야
+          </label>
+          <select
+            id="day_or_night"
+            name="day_or_night"
+            value={formData.day_or_night}
+            onChange={handleChange}
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          >
+            <option value="day">주간</option>
+            <option value="night">야간</option>
+          </select>
+        </div>
+        
+        <div>
+          <label htmlFor="delivery_area" className="block text-sm font-medium text-gray-700">
+            배송구역
+          </label>
+          <input
+            type="text"
+            id="delivery_area"
+            name="delivery_area"
+            value={formData.delivery_area}
+            onChange={handleChange}
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="courier_name" className="block text-sm font-medium text-gray-700">
+            이름
+          </label>
+          <input
+            type="text"
+            id="courier_name"
+            name="courier_name"
+            value={formData.courier_name}
+            onChange={handleChange}
+            required
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="delivery_count" className="block text-sm font-medium text-gray-700">
+            건수
+          </label>
+          <input
+            type="number"
+            id="delivery_count"
+            name="delivery_count"
+            value={formData.delivery_count}
+            onChange={handleChange}
+            required
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="unit_price" className="block text-sm font-medium text-gray-700">
+            단가(VAT별도)
+          </label>
+          <input
+            type="number"
+            id="unit_price"
+            name="unit_price"
+            value={formData.unit_price}
+            onChange={handleChange}
+            required
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="supply_price" className="block text-sm font-medium text-gray-700">
+            공급가
+          </label>
+          <input
+            type="number"
+            id="supply_price"
+            name="supply_price"
+            value={formData.supply_price}
+            onChange={handleChange}
+            required
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="vat" className="block text-sm font-medium text-gray-700">
+            부가세
+          </label>
+          <input
+            type="number"
+            id="vat"
+            name="vat"
+            value={formData.vat}
+            onChange={handleChange}
+            required
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="total_amount" className="block text-sm font-medium text-gray-700">
+            합계
+          </label>
+          <input
+            type="number"
+            id="total_amount"
+            name="total_amount"
+            value={formData.total_amount}
+            onChange={handleChange}
+            required
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="profit" className="block text-sm font-medium text-gray-700">
+            수익금
+          </label>
+          <input
+            type="number"
+            id="profit"
+            name="profit"
+            value={formData.profit}
+            onChange={handleChange}
+            required
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="invoice_status" className="block text-sm font-medium text-gray-700">
+            계산서
+          </label>
+          <input
+            type="text"
+            id="invoice_status"
+            name="invoice_status"
+            value={formData.invoice_status}
+            onChange={handleChange}
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="payment_type" className="block text-sm font-medium text-gray-700">
+            입금형태
+          </label>
+          <input
+            type="text"
+            id="payment_type"
+            name="payment_type"
+            value={formData.payment_type}
+            onChange={handleChange}
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="transaction_partner" className="block text-sm font-medium text-gray-700">
+            거래처(입금처)
+          </label>
+          <input
+            type="text"
+            id="transaction_partner"
+            name="transaction_partner"
+            value={formData.transaction_partner}
+            onChange={handleChange}
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="return_count" className="block text-sm font-medium text-gray-700">
+            반품건수
+          </label>
+          <input
+            type="number"
+            id="return_count"
+            name="return_count"
+            value={formData.return_count}
+            onChange={handleChange}
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="camp" className="block text-sm font-medium text-gray-700">
+            캠프
+          </label>
+          <input
+            type="text"
+            id="camp"
+            name="camp"
+            value={formData.camp}
+            onChange={handleChange}
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="route_id" className="block text-sm font-medium text-gray-700">
+            라우트
+          </label>
+          <input
+            type="text"
+            id="route_id"
+            name="route_id"
+            value={formData.route_id}
+            onChange={handleChange}
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="pdd" className="block text-sm font-medium text-gray-700">
+            PDD
+          </label>
+          <input
+            type="text"
+            id="pdd"
+            name="pdd"
+            value={formData.pdd}
+            onChange={handleChange}
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div className="md:col-span-2 lg:col-span-3">
+          <label htmlFor="note" className="block text-sm font-medium text-gray-700">
+            비고
+          </label>
+          <input
+            type="text"
+            id="note"
+            name="note"
+            value={formData.note}
+            onChange={handleChange}
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+      </div>
+      
+      <div className="flex justify-end space-x-3">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 bg-gray-300 text-gray-800 rounded-md hover:bg-gray-400"
+        >
+          취소
+        </button>
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600"
+        >
+          저장
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default CoupangSettlementForm;

--- a/src/components/settlements/EditableTable.tsx
+++ b/src/components/settlements/EditableTable.tsx
@@ -1,0 +1,153 @@
+import React, { useState, useEffect } from 'react';
+import { GeneralSettlementRow } from '@/lib/types/settlement';
+
+interface EditableTableProps {
+  columns: string[];
+  rows: GeneralSettlementRow[];
+  onChange: (columns: string[], rows: GeneralSettlementRow[]) => void;
+}
+
+const EditableTable: React.FC<EditableTableProps> = ({
+  columns: initialColumns,
+  rows: initialRows,
+  onChange,
+}) => {
+  const [columns, setColumns] = useState<string[]>(initialColumns);
+  const [rows, setRows] = useState<GeneralSettlementRow[]>(initialRows);
+  const [newColumnName, setNewColumnName] = useState<string>('');
+
+  useEffect(() => {
+    // Update parent component when table data changes
+    onChange(columns, rows);
+  }, [columns, rows, onChange]);
+
+  const handleCellChange = (rowIndex: number, columnName: string, value: string) => {
+    const newRows = [...rows];
+    newRows[rowIndex] = {
+      ...newRows[rowIndex],
+      [columnName]: value,
+    };
+    setRows(newRows);
+  };
+
+  const addRow = () => {
+    const newRow: GeneralSettlementRow = { row_id: rows.length };
+    columns.forEach((col) => {
+      newRow[col] = '';
+    });
+    setRows([...rows, newRow]);
+  };
+
+  const removeRow = (rowIndex: number) => {
+    const newRows = [...rows];
+    newRows.splice(rowIndex, 1);
+    setRows(newRows);
+  };
+
+  const addColumn = () => {
+    if (!newColumnName.trim()) return;
+    
+    if (columns.includes(newColumnName)) {
+      alert('Column already exists');
+      return;
+    }
+    
+    setColumns([...columns, newColumnName]);
+    
+    // Add the new column to all existing rows
+    const newRows = rows.map((row) => ({
+      ...row,
+      [newColumnName]: '',
+    }));
+    
+    setRows(newRows);
+    setNewColumnName('');
+  };
+
+  const removeColumn = (columnName: string) => {
+    const newColumns = columns.filter((col) => col !== columnName);
+    setColumns(newColumns);
+    
+    // Remove the column from all rows
+    const newRows = rows.map((row) => {
+      const newRow = { ...row };
+      delete newRow[columnName];
+      return newRow;
+    });
+    
+    setRows(newRows);
+  };
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="mb-4 flex space-x-2">
+        <input
+          type="text"
+          value={newColumnName}
+          onChange={(e) => setNewColumnName(e.target.value)}
+          placeholder="New column name"
+          className="border p-2 rounded"
+        />
+        <button
+          onClick={addColumn}
+          className="bg-green-500 text-white px-3 py-2 rounded hover:bg-green-600"
+        >
+          Add Column
+        </button>
+        <button
+          onClick={addRow}
+          className="bg-blue-500 text-white px-3 py-2 rounded hover:bg-blue-600"
+        >
+          Add Row
+        </button>
+      </div>
+      
+      <table className="min-w-full border border-gray-300">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="border p-2 text-center">Actions</th>
+            {columns.map((column, colIdx) => (
+              <th key={colIdx} className="border p-2">
+                <div className="flex items-center justify-between">
+                  <span>{column}</span>
+                  <button
+                    onClick={() => removeColumn(column)}
+                    className="text-red-500 ml-2 hover:text-red-700"
+                  >
+                    ✕
+                  </button>
+                </div>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, rowIdx) => (
+            <tr key={rowIdx} className={rowIdx % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+              <td className="border p-2 text-center">
+                <button
+                  onClick={() => removeRow(rowIdx)}
+                  className="text-red-500 hover:text-red-700"
+                >
+                  Delete
+                </button>
+              </td>
+              {columns.map((column, colIdx) => (
+                <td key={colIdx} className="border p-2">
+                  <input
+                    type="text"
+                    value={row[column]?.toString() || ''}
+                    onChange={(e) => handleCellChange(rowIdx, column, e.target.value)}
+                    className="w-full p-1 border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default EditableTable;

--- a/src/components/settlements/GeneralSettlementForm.tsx
+++ b/src/components/settlements/GeneralSettlementForm.tsx
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from 'react';
+import { GeneralSettlementRow, CreateGeneralSettlementDTO } from '@/lib/types/settlement';
+import EditableTable from './EditableTable';
+
+interface GeneralSettlementFormProps {
+  initialData?: { columns: string[]; rows: GeneralSettlementRow[] };
+  onSubmit: (data: CreateGeneralSettlementDTO) => void;
+  onCancel: () => void;
+}
+
+const GeneralSettlementForm: React.FC<GeneralSettlementFormProps> = ({
+  initialData,
+  onSubmit,
+  onCancel,
+}) => {
+  const [columns, setColumns] = useState<string[]>(
+    initialData?.columns || ['날짜', '이름', '금액', '비고']
+  );
+  
+  const [rows, setRows] = useState<GeneralSettlementRow[]>(
+    initialData?.rows || [{ row_id: 0 }]
+  );
+
+  useEffect(() => {
+    if (initialData) {
+      setColumns(initialData.columns);
+      setRows(initialData.rows);
+    }
+  }, [initialData]);
+
+  const handleTableChange = (newColumns: string[], newRows: GeneralSettlementRow[]) => {
+    setColumns(newColumns);
+    setRows(newRows);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({
+      columns,
+      rows,
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="bg-white p-4 rounded-md border">
+        <h3 className="text-lg font-medium mb-4">정산서 데이터 편집</h3>
+        <EditableTable 
+          columns={columns}
+          rows={rows}
+          onChange={handleTableChange}
+        />
+      </div>
+      
+      <div className="flex justify-end space-x-3">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 bg-gray-300 text-gray-800 rounded-md hover:bg-gray-400"
+        >
+          취소
+        </button>
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600"
+        >
+          저장
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default GeneralSettlementForm;

--- a/src/components/settlements/KurlySettlementForm.tsx
+++ b/src/components/settlements/KurlySettlementForm.tsx
@@ -1,0 +1,251 @@
+import React, { useState, useEffect } from 'react';
+import { KurlySettlement, CreateKurlySettlementDTO } from '@/lib/types/settlement';
+
+interface KurlySettlementFormProps {
+  initialData?: KurlySettlement;
+  onSubmit: (data: CreateKurlySettlementDTO) => void;
+  onCancel: () => void;
+}
+
+const KurlySettlementForm: React.FC<KurlySettlementFormProps> = ({
+  initialData,
+  onSubmit,
+  onCancel,
+}) => {
+  const [formData, setFormData] = useState<CreateKurlySettlementDTO>({
+    company_name: '',
+    settlement_date: new Date().toISOString().split('T')[0],
+    support_type: '',
+    amount: 0,
+    note: '',
+    settlement_amount: 0,
+    supply_price: 0,
+    delivery_count: 0,
+    unit_price: 0,
+    center: '',
+    region: '',
+  });
+
+  useEffect(() => {
+    if (initialData) {
+      setFormData({
+        company_name: initialData.company_name,
+        settlement_date: initialData.settlement_date || new Date().toISOString().split('T')[0],
+        support_type: initialData.support_type || '',
+        amount: initialData.amount,
+        note: initialData.note || '',
+        settlement_amount: initialData.settlement_amount,
+        supply_price: initialData.supply_price,
+        delivery_count: initialData.delivery_count || 0,
+        unit_price: initialData.unit_price || 0,
+        center: initialData.center || '',
+        region: initialData.region || '',
+      });
+    }
+  }, [initialData]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    
+    // Handle numeric fields
+    if (['amount', 'settlement_amount', 'supply_price', 'delivery_count', 'unit_price'].includes(name)) {
+      setFormData({
+        ...formData,
+        [name]: parseFloat(value) || 0,
+      });
+    } else {
+      setFormData({
+        ...formData,
+        [name]: value,
+      });
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit(formData);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="company_name" className="block text-sm font-medium text-gray-700">
+            업체명
+          </label>
+          <input
+            type="text"
+            id="company_name"
+            name="company_name"
+            value={formData.company_name}
+            onChange={handleChange}
+            required
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="settlement_date" className="block text-sm font-medium text-gray-700">
+            날짜
+          </label>
+          <input
+            type="date"
+            id="settlement_date"
+            name="settlement_date"
+            value={formData.settlement_date}
+            onChange={handleChange}
+            required
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="support_type" className="block text-sm font-medium text-gray-700">
+            지원/대처
+          </label>
+          <input
+            type="text"
+            id="support_type"
+            name="support_type"
+            value={formData.support_type}
+            onChange={handleChange}
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="amount" className="block text-sm font-medium text-gray-700">
+            금액(만원)
+          </label>
+          <input
+            type="number"
+            id="amount"
+            name="amount"
+            value={formData.amount}
+            onChange={handleChange}
+            required
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="settlement_amount" className="block text-sm font-medium text-gray-700">
+            정산금액
+          </label>
+          <input
+            type="number"
+            id="settlement_amount"
+            name="settlement_amount"
+            value={formData.settlement_amount}
+            onChange={handleChange}
+            required
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="supply_price" className="block text-sm font-medium text-gray-700">
+            공급가
+          </label>
+          <input
+            type="number"
+            id="supply_price"
+            name="supply_price"
+            value={formData.supply_price}
+            onChange={handleChange}
+            required
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="delivery_count" className="block text-sm font-medium text-gray-700">
+            딜리건수
+          </label>
+          <input
+            type="number"
+            id="delivery_count"
+            name="delivery_count"
+            value={formData.delivery_count}
+            onChange={handleChange}
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="unit_price" className="block text-sm font-medium text-gray-700">
+            단가
+          </label>
+          <input
+            type="number"
+            id="unit_price"
+            name="unit_price"
+            value={formData.unit_price}
+            onChange={handleChange}
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="center" className="block text-sm font-medium text-gray-700">
+            센터
+          </label>
+          <input
+            type="text"
+            id="center"
+            name="center"
+            value={formData.center}
+            onChange={handleChange}
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div>
+          <label htmlFor="region" className="block text-sm font-medium text-gray-700">
+            지역
+          </label>
+          <input
+            type="text"
+            id="region"
+            name="region"
+            value={formData.region}
+            onChange={handleChange}
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+        
+        <div className="md:col-span-2">
+          <label htmlFor="note" className="block text-sm font-medium text-gray-700">
+            비고
+          </label>
+          <input
+            type="text"
+            id="note"
+            name="note"
+            value={formData.note}
+            onChange={handleChange}
+            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+          />
+        </div>
+      </div>
+      
+      <div className="flex justify-end space-x-3">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 bg-gray-300 text-gray-800 rounded-md hover:bg-gray-400"
+        >
+          취소
+        </button>
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600"
+        >
+          저장
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default KurlySettlementForm;

--- a/src/components/settlements/SettlementList.tsx
+++ b/src/components/settlements/SettlementList.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { Settlement } from '@/lib/types/settlement';
+import Link from 'next/link';
+
+interface SettlementListProps {
+  settlements: Settlement[];
+  onDeleteSettlement: (id: string) => void;
+}
+
+const SettlementList: React.FC<SettlementListProps> = ({
+  settlements,
+  onDeleteSettlement,
+}) => {
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+  };
+
+  const getSettlementTypeName = (type: string) => {
+    switch (type) {
+      case 'kurly':
+        return '컬리';
+      case 'coupang':
+        return '쿠팡';
+      case 'general':
+        return '정산서(편집용)';
+      default:
+        return type;
+    }
+  };
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            <th
+              scope="col"
+              className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+            >
+              날짜
+            </th>
+            <th
+              scope="col"
+              className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+            >
+              유형
+            </th>
+            <th
+              scope="col"
+              className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+            >
+              작성일
+            </th>
+            <th
+              scope="col"
+              className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
+            >
+              작업
+            </th>
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-200">
+          {settlements.length === 0 ? (
+            <tr>
+              <td colSpan={4} className="px-6 py-4 text-center text-sm text-gray-500">
+                정산 데이터가 없습니다.
+              </td>
+            </tr>
+          ) : (
+            settlements.map((settlement) => (
+              <tr key={settlement.id} className="hover:bg-gray-50">
+                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                  {formatDate(settlement.settlement_date)}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  {getSettlementTypeName(settlement.settlement_type)}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  {formatDate(settlement.created_at)}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                  <Link
+                    href={`/dashboard/settlements/${settlement.id}`}
+                    className="text-blue-600 hover:text-blue-900 mr-4"
+                  >
+                    보기
+                  </Link>
+                  <Link
+                    href={`/dashboard/settlements/edit/${settlement.id}`}
+                    className="text-indigo-600 hover:text-indigo-900 mr-4"
+                  >
+                    수정
+                  </Link>
+                  <button
+                    onClick={() => onDeleteSettlement(settlement.id)}
+                    className="text-red-600 hover:text-red-900"
+                  >
+                    삭제
+                  </button>
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default SettlementList;

--- a/src/lib/settlements.ts
+++ b/src/lib/settlements.ts
@@ -1,0 +1,315 @@
+import { createClient } from './supabase';
+import { 
+  Settlement, 
+  KurlySettlement, 
+  CoupangSettlement, 
+  GeneralSettlementColumn, 
+  GeneralSettlementRow,
+  CreateKurlySettlementDTO,
+  CreateCoupangSettlementDTO,
+  CreateGeneralSettlementDTO
+} from './types/settlement';
+
+// Common settlement functions
+export async function getSettlements() {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('settlements')
+    .select('*')
+    .order('settlement_date', { ascending: false });
+
+  if (error) throw error;
+  return data as Settlement[];
+}
+
+export async function getSettlementById(id: string) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('settlements')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (error) throw error;
+  return data as Settlement;
+}
+
+export async function createSettlement(
+  settlement_date: string, 
+  settlement_type: 'kurly' | 'coupang' | 'general'
+) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('settlements')
+    .insert({
+      settlement_date,
+      settlement_type
+    })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as Settlement;
+}
+
+export async function updateSettlement(
+  id: string,
+  settlement_date: string
+) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('settlements')
+    .update({
+      settlement_date,
+      updated_at: new Date().toISOString()
+    })
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as Settlement;
+}
+
+export async function deleteSettlement(id: string) {
+  const supabase = createClient();
+  const { error } = await supabase
+    .from('settlements')
+    .delete()
+    .eq('id', id);
+
+  if (error) throw error;
+  return true;
+}
+
+// Kurly settlements
+export async function getKurlySettlements(settlement_id: string) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('kurly_settlements')
+    .select('*')
+    .eq('settlement_id', settlement_id)
+    .order('created_at', { ascending: true });
+
+  if (error) throw error;
+  return data as KurlySettlement[];
+}
+
+export async function createKurlySettlement(
+  settlement_id: string,
+  kurlySettlement: CreateKurlySettlementDTO
+) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('kurly_settlements')
+    .insert({
+      settlement_id,
+      ...kurlySettlement
+    })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as KurlySettlement;
+}
+
+export async function updateKurlySettlement(
+  id: string,
+  kurlySettlement: Partial<CreateKurlySettlementDTO>
+) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('kurly_settlements')
+    .update({
+      ...kurlySettlement,
+      updated_at: new Date().toISOString()
+    })
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as KurlySettlement;
+}
+
+export async function deleteKurlySettlement(id: string) {
+  const supabase = createClient();
+  const { error } = await supabase
+    .from('kurly_settlements')
+    .delete()
+    .eq('id', id);
+
+  if (error) throw error;
+  return true;
+}
+
+// Coupang settlements
+export async function getCoupangSettlements(settlement_id: string) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('coupang_settlements')
+    .select('*')
+    .eq('settlement_id', settlement_id)
+    .order('created_at', { ascending: true });
+
+  if (error) throw error;
+  return data as CoupangSettlement[];
+}
+
+export async function createCoupangSettlement(
+  settlement_id: string,
+  coupangSettlement: CreateCoupangSettlementDTO
+) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('coupang_settlements')
+    .insert({
+      settlement_id,
+      ...coupangSettlement
+    })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as CoupangSettlement;
+}
+
+export async function updateCoupangSettlement(
+  id: string,
+  coupangSettlement: Partial<CreateCoupangSettlementDTO>
+) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('coupang_settlements')
+    .update({
+      ...coupangSettlement,
+      updated_at: new Date().toISOString()
+    })
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as CoupangSettlement;
+}
+
+export async function deleteCoupangSettlement(id: string) {
+  const supabase = createClient();
+  const { error } = await supabase
+    .from('coupang_settlements')
+    .delete()
+    .eq('id', id);
+
+  if (error) throw error;
+  return true;
+}
+
+// General settlements (fully editable version)
+export async function getGeneralSettlementColumns(settlement_id: string) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('general_settlements')
+    .select('*')
+    .eq('settlement_id', settlement_id)
+    .order('row_order', { ascending: true });
+
+  if (error) throw error;
+  
+  // Group by row_order to create a proper table structure
+  const rows: GeneralSettlementRow[] = [];
+  const columns = new Set<string>();
+  
+  // First, collect all unique column names
+  data.forEach((col: GeneralSettlementColumn) => {
+    columns.add(col.column_name);
+  });
+  
+  // Then create rows with all columns
+  const rowMap = new Map<number, GeneralSettlementRow>();
+  
+  data.forEach((col: GeneralSettlementColumn) => {
+    if (!rowMap.has(col.row_order)) {
+      rowMap.set(col.row_order, { row_id: col.row_order });
+    }
+    
+    const row = rowMap.get(col.row_order);
+    if (row) {
+      row[col.column_name] = col.column_value || '';
+    }
+  });
+  
+  // Convert map to array
+  rowMap.forEach((row) => {
+    rows.push(row);
+  });
+  
+  return {
+    columns: Array.from(columns),
+    rows
+  };
+}
+
+export async function createGeneralSettlement(
+  settlement_id: string,
+  generalSettlement: CreateGeneralSettlementDTO
+) {
+  const supabase = createClient();
+  const { columns, rows } = generalSettlement;
+  
+  // Convert to database format
+  const insertData = [];
+  
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+    const row = rows[rowIndex];
+    
+    for (const column of columns) {
+      insertData.push({
+        settlement_id,
+        row_order: rowIndex,
+        column_name: column,
+        column_value: row[column]?.toString() || null
+      });
+    }
+  }
+  
+  const { data, error } = await supabase
+    .from('general_settlements')
+    .insert(insertData)
+    .select();
+
+  if (error) throw error;
+  return {
+    columns,
+    rows
+  };
+}
+
+export async function updateGeneralSettlement(
+  settlement_id: string,
+  generalSettlement: CreateGeneralSettlementDTO
+) {
+  // For simplicity, we'll delete all existing entries and recreate them
+  const supabase = createClient();
+  
+  // First delete existing entries
+  const { error: deleteError } = await supabase
+    .from('general_settlements')
+    .delete()
+    .eq('settlement_id', settlement_id);
+    
+  if (deleteError) throw deleteError;
+  
+  // Then create new ones
+  return createGeneralSettlement(settlement_id, generalSettlement);
+}
+
+export async function deleteGeneralSettlement(settlement_id: string) {
+  const supabase = createClient();
+  const { error } = await supabase
+    .from('general_settlements')
+    .delete()
+    .eq('settlement_id', settlement_id);
+
+  if (error) throw error;
+  return true;
+}

--- a/src/lib/types/settlement.ts
+++ b/src/lib/types/settlement.ts
@@ -1,0 +1,105 @@
+export interface Settlement {
+  id: string;
+  settlement_date: string;
+  settlement_type: 'kurly' | 'coupang' | 'general';
+  created_at: string;
+  updated_at: string;
+  created_by: string;
+}
+
+export interface KurlySettlement {
+  id: string;
+  settlement_id: string;
+  company_name: string; // 업체명
+  settlement_date?: string; // 날짜
+  support_type?: string; // 지원/대처
+  amount: number; // 금액(만원)
+  note?: string; // 비고
+  settlement_amount: number; // 정산금액
+  supply_price: number; // 공급가
+  delivery_count?: number; // 딜리건수
+  unit_price?: number; // 단가
+  center?: string; // 센터
+  region?: string; // 지역
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CoupangSettlement {
+  id: string;
+  settlement_id: string;
+  settlement_date: string; // 날짜
+  day_or_night?: string; // 주/야
+  delivery_area?: string; // 배송구역
+  courier_name: string; // 이름
+  delivery_count: number; // 건수
+  unit_price: number; // 단가(vat별도)
+  supply_price: number; // 공급가
+  vat: number; // 부가세
+  total_amount: number; // 합계
+  profit: number; // 수익금
+  invoice_status?: string; // 계산서
+  payment_type?: string; // 입금형태
+  note?: string; // 비고
+  transaction_partner?: string; // 거래처(입금처)
+  return_count?: number; // 반품건수
+  camp?: string; // 캠프
+  route_id?: string; // 라우트
+  pdd?: string; // PDD
+  created_at: string;
+  updated_at: string;
+}
+
+export interface GeneralSettlementColumn {
+  id: string;
+  settlement_id: string;
+  row_order: number;
+  column_name: string;
+  column_value?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface GeneralSettlementRow {
+  [columnName: string]: string | number | null | undefined;
+}
+
+export interface CreateKurlySettlementDTO {
+  company_name: string;
+  settlement_date: string;
+  support_type?: string;
+  amount: number;
+  note?: string;
+  settlement_amount: number;
+  supply_price: number;
+  delivery_count?: number;
+  unit_price?: number;
+  center?: string;
+  region?: string;
+}
+
+export interface CreateCoupangSettlementDTO {
+  settlement_date: string;
+  day_or_night?: string;
+  delivery_area?: string;
+  courier_name: string;
+  delivery_count: number;
+  unit_price: number;
+  supply_price: number;
+  vat: number;
+  total_amount: number;
+  profit: number;
+  invoice_status?: string;
+  payment_type?: string;
+  note?: string;
+  transaction_partner?: string;
+  return_count?: number;
+  camp?: string;
+  route_id?: string;
+  pdd?: string;
+}
+
+export interface CreateGeneralSettlementDTO {
+  columns: string[];
+  rows: GeneralSettlementRow[];
+}


### PR DESCRIPTION
## 정산 시스템 추가

이 PR은 택배기사 물류센터 배치 관리 시스템에 정산 기능을 추가합니다. 다음과 같은 세 가지 유형의 정산 관리 기능을 구현했습니다:

### 1. 컬리 정산 관리
- 업체명, 날짜, 지원/대처, 금액(만원), 비고, 정산금액, 공급가, 딜리건수, 단가, 센터, 지역 등의 정보 관리
- 데이터 추가, 수정, 삭제 기능

### 2. 쿠팡 정산 관리
- 날짜, 주/야, 배송구역, 이름, 건수, 단가(vat별도), 공급가, 부가세, 합계, 수익금, 계산서, 입금형태, 비고, 거래처(입금처), 반품건수, 캠프, 라우트, PDD 등의 정보 관리
- 단가와 건수 입력 시 공급가, 부가세, 합계 자동 계산 기능
- 데이터 추가, 수정, 삭제 기능

### 3. 편집용 정산 관리
- 완전히 커스터마이즈 가능한 테이블 형태의 정산 데이터 관리
- 컬럼 추가/삭제, 행 추가/삭제 기능
- 모든 셀 데이터 자유롭게 편집 가능

### 기술적 변경사항
- 데이터베이스 스키마 추가 (settlements, kurly_settlements, coupang_settlements, general_settlements 테이블)
- 타입 정의 추가
- API 서비스 함수 추가
- UI 컴포넌트 개발
- 데이터 조회, 추가, 수정, 삭제 페이지 구현
- 사이드바 메뉴 업데이트

### 스크린샷
(스크린샷 또는 영상 첨부)