### PR TITLE
정산 시스템 구현

### DIFF
--- a/database/migration_settlement_system.sql
+++ b/database/migration_settlement_system.sql
@@ -1,0 +1,152 @@
+-- database/migration_settlement_system.sql
+
+-- 1. Create table for general settlements (legacy support)
+CREATE TABLE IF NOT EXISTS settlements (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  courier_id UUID REFERENCES users(id) NOT NULL,
+  delivery_date DATE NOT NULL,
+  delivery_fee NUMERIC(10, 0) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  created_by UUID REFERENCES users(id),
+  updated_at TIMESTAMP WITH TIME ZONE
+);
+
+-- 2. Create table for Kurly settlements
+CREATE TABLE IF NOT EXISTS kurly_settlements (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  courier_id UUID REFERENCES users(id) NOT NULL,
+  delivery_date DATE NOT NULL,
+  shift TEXT,
+  sequence TEXT,
+  delivery_fee NUMERIC(10, 0) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  created_by UUID REFERENCES users(id),
+  updated_at TIMESTAMP WITH TIME ZONE
+);
+
+-- 3. Create table for Coupang settlements
+CREATE TABLE IF NOT EXISTS coupang_settlements (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  courier_id UUID REFERENCES users(id) NOT NULL,
+  delivery_date DATE NOT NULL,
+  delivery_code TEXT,
+  delivery_count INTEGER,
+  unit_price NUMERIC(10, 0),
+  weight NUMERIC(10, 1),
+  delivery_fee NUMERIC(10, 0) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  created_by UUID REFERENCES users(id),
+  updated_at TIMESTAMP WITH TIME ZONE
+);
+
+-- 4. Create table for settlement statements
+CREATE TABLE IF NOT EXISTS settlement_statements (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  courier_id UUID REFERENCES users(id) NOT NULL,
+  start_date DATE NOT NULL,
+  end_date DATE NOT NULL,
+  total_amount NUMERIC(12, 0) NOT NULL,
+  commission_rate NUMERIC(5, 2) NOT NULL,
+  commission_amount NUMERIC(12, 0) NOT NULL,
+  final_amount NUMERIC(12, 0) NOT NULL,
+  vat_amount NUMERIC(12, 0) DEFAULT 0,
+  payment_status TEXT DEFAULT 'pending' CHECK (payment_status IN ('pending', 'paid', 'cancelled')),
+  payment_date DATE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  created_by UUID REFERENCES users(id),
+  updated_at TIMESTAMP WITH TIME ZONE
+);
+
+-- 5. Create table for settlement adjustments
+CREATE TABLE IF NOT EXISTS settlement_adjustments (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  statement_id UUID REFERENCES settlement_statements(id) ON DELETE CASCADE,
+  description TEXT NOT NULL,
+  amount NUMERIC(10, 0) NOT NULL,
+  type TEXT CHECK (type IN ('expense', 'income', 'tax', 'other')),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  created_by UUID REFERENCES users(id)
+);
+
+-- 6. Create index for faster queries
+CREATE INDEX IF NOT EXISTS idx_settlements_courier_date ON settlements (courier_id, delivery_date);
+CREATE INDEX IF NOT EXISTS idx_kurly_settlements_courier_date ON kurly_settlements (courier_id, delivery_date);
+CREATE INDEX IF NOT EXISTS idx_coupang_settlements_courier_date ON coupang_settlements (courier_id, delivery_date);
+CREATE INDEX IF NOT EXISTS idx_settlement_statements_courier ON settlement_statements (courier_id);
+
+-- 7. Set up RLS (Row Level Security) policies
+-- For settlements
+ALTER TABLE settlements ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY settlements_select_policy ON settlements
+  FOR SELECT USING (
+    auth.uid() = courier_id OR 
+    EXISTS (SELECT 1 FROM users WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY settlements_insert_policy ON settlements
+  FOR INSERT WITH CHECK (
+    auth.uid() = courier_id OR 
+    EXISTS (SELECT 1 FROM users WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- For kurly_settlements
+ALTER TABLE kurly_settlements ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY kurly_settlements_select_policy ON kurly_settlements
+  FOR SELECT USING (
+    auth.uid() = courier_id OR 
+    EXISTS (SELECT 1 FROM users WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY kurly_settlements_insert_policy ON kurly_settlements
+  FOR INSERT WITH CHECK (
+    auth.uid() = courier_id OR 
+    EXISTS (SELECT 1 FROM users WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- For coupang_settlements
+ALTER TABLE coupang_settlements ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY coupang_settlements_select_policy ON coupang_settlements
+  FOR SELECT USING (
+    auth.uid() = courier_id OR 
+    EXISTS (SELECT 1 FROM users WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY coupang_settlements_insert_policy ON coupang_settlements
+  FOR INSERT WITH CHECK (
+    auth.uid() = courier_id OR 
+    EXISTS (SELECT 1 FROM users WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- For settlement_statements
+ALTER TABLE settlement_statements ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY settlement_statements_select_policy ON settlement_statements
+  FOR SELECT USING (
+    auth.uid() = courier_id OR 
+    EXISTS (SELECT 1 FROM users WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY settlement_statements_insert_policy ON settlement_statements
+  FOR INSERT WITH CHECK (
+    EXISTS (SELECT 1 FROM users WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- For settlement_adjustments
+ALTER TABLE settlement_adjustments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY settlement_adjustments_select_policy ON settlement_adjustments
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM settlement_statements s
+      WHERE s.id = settlement_adjustments.statement_id
+      AND (s.courier_id = auth.uid() OR EXISTS (SELECT 1 FROM users WHERE id = auth.uid() AND role = 'admin'))
+    )
+  );
+
+CREATE POLICY settlement_adjustments_insert_policy ON settlement_adjustments
+  FOR INSERT WITH CHECK (
+    EXISTS (SELECT 1 FROM users WHERE id = auth.uid() AND role = 'admin')
+  );

--- a/src/app/dashboard/settlements/report/page.tsx
+++ b/src/app/dashboard/settlements/report/page.tsx
@@ -1,0 +1,351 @@
+// src/app/dashboard/settlements/report/page.tsx
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { getCourierById } from '@/lib/couriers';
+import { getSettlements, getKurlySettlements, getCoupangSettlements } from '@/lib/settlements';
+import { Settlement, KurlySettlement, CoupangSettlement } from '@/lib/types/settlement';
+import Link from 'next/link';
+import { FiArrowLeft, FiPrinter, FiDownload } from 'react-icons/fi';
+import toast from 'react-hot-toast';
+
+export default function SettlementReportPage() {
+  const searchParams = useSearchParams();
+  const courierId = searchParams.get('courier_id');
+  const startDate = searchParams.get('start_date');
+  const endDate = searchParams.get('end_date');
+  
+  const [isLoading, setIsLoading] = useState(true);
+  const [courier, setCourier] = useState<any>(null);
+  const [kurlySettlements, setKurlySettlements] = useState<KurlySettlement[]>([]);
+  const [coupangSettlements, setCoupangSettlements] = useState<CoupangSettlement[]>([]);
+  
+  const [commissionRate, setCommissionRate] = useState(8);
+  
+  useEffect(() => {
+    async function loadData() {
+      if (!courierId || !startDate || !endDate) {
+        toast.error('필수 파라미터가 누락되었습니다.');
+        return;
+      }
+      
+      try {
+        // Load courier data
+        const courierData = await getCourierById(courierId);
+        setCourier(courierData);
+        
+        // Load settlements
+        const [kurlyData, coupangData] = await Promise.all([
+          getKurlySettlements(courierId, startDate, endDate),
+          getCoupangSettlements(courierId, startDate, endDate)
+        ]);
+        
+        setKurlySettlements(kurlyData);
+        setCoupangSettlements(coupangData);
+        
+        setIsLoading(false);
+      } catch (error) {
+        console.error('Error loading report data:', error);
+        toast.error('데이터를 불러오는데 실패했습니다.');
+        setIsLoading(false);
+      }
+    }
+    
+    loadData();
+  }, [courierId, startDate, endDate]);
+  
+  function handlePrint() {
+    window.print();
+  }
+  
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-primary-500"></div>
+      </div>
+    );
+  }
+  
+  if (!courier) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <h3 className="text-xl font-medium text-secondary-800 mb-2">기사 정보를 찾을 수 없습니다.</h3>
+          <p className="text-secondary-600 mb-4">요청하신 기사 정보가 존재하지 않습니다.</p>
+          <Link href="/dashboard/settlements/reports" className="btn-secondary">
+            돌아가기
+          </Link>
+        </div>
+      </div>
+    );
+  }
+  
+  // Calculate totals
+  const kurlyTotal = kurlySettlements.reduce((sum, item) => sum + item.delivery_fee, 0);
+  const coupangTotal = coupangSettlements.reduce((sum, item) => sum + item.delivery_fee, 0);
+  const totalAmount = kurlyTotal + coupangTotal;
+  
+  // Calculate commissions and final amounts
+  const commissionAmount = Math.round(totalAmount * (commissionRate / 100));
+  const vatAmount = Math.round((totalAmount - commissionAmount) * 0.1);
+  const finalAmount = totalAmount - commissionAmount + vatAmount;
+  
+  return (
+    <div className="py-6">
+      <div className="print:hidden flex justify-between items-center mb-6">
+        <div className="flex items-center">
+          <Link href="/dashboard/settlements/reports" className="mr-4 text-secondary-600 hover:text-secondary-800">
+            <FiArrowLeft size={20} />
+          </Link>
+          <h2 className="text-2xl font-semibold text-secondary-800">정산서</h2>
+        </div>
+        <div className="flex space-x-2">
+          <button onClick={handlePrint} className="btn-secondary">
+            <FiPrinter className="mr-2" />
+            인쇄
+          </button>
+          <button className="btn-primary">
+            <FiDownload className="mr-2" />
+            PDF 다운로드
+          </button>
+        </div>
+      </div>
+      
+      <div className="card print:shadow-none print:border-none print:m-0 print:p-0">
+        <div className="p-8 print:p-0">
+          {/* 정산서 헤더 */}
+          <div className="text-center mb-8">
+            <h1 className="text-xl font-bold mb-1">[ {new Date(endDate || '').getFullYear()}년 {new Date(endDate || '').getMonth() + 1}월 ] 정산서</h1>
+            <div className="border-t-2 border-b-2 border-black py-2 my-4">
+              <div className="flex">
+                <div className="w-24 text-right pr-2 font-semibold">이름 :</div>
+                <div className="w-48 bg-yellow-100 px-2">{courier?.name || '알 수 없음'}</div>
+              </div>
+            </div>
+          </div>
+          
+          {/* 정산 요약 */}
+          <div className="mb-8">
+            <div className="border border-gray-300">
+              <div className="font-semibold bg-orange-100 p-2 border-b border-gray-300">정산 상세</div>
+              <div className="divide-y divide-gray-300">
+                <div className="flex">
+                  <div className="w-1/4 text-center py-2 px-3 font-semibold border-r border-gray-300">구분</div>
+                  <div className="w-3/4 text-right py-2 px-3 font-semibold">금액</div>
+                </div>
+                <div className="flex">
+                  <div className="w-1/4 py-2 px-3 border-r border-gray-300">컨리 외</div>
+                  <div className="w-3/4 text-right py-2 px-3">{kurlyTotal.toLocaleString()}</div>
+                </div>
+                <div className="flex">
+                  <div className="w-1/4 py-2 px-3 border-r border-gray-300">쿠팡 외</div>
+                  <div className="w-3/4 text-right py-2 px-3 bg-yellow-100">{coupangTotal.toLocaleString()}</div>
+                </div>
+                <div className="flex">
+                  <div className="w-1/4 py-2 px-3 border-r border-gray-300 font-semibold">수수료<br/>(부가세 별도)</div>
+                  <div className="w-3/4 text-right py-2 px-3">0</div>
+                </div>
+                <div className="flex">
+                  <div className="w-1/4 py-2 px-3 border-r border-gray-300">추가정산</div>
+                  <div className="w-3/4 text-right py-2 px-3">0</div>
+                </div>
+                <div className="flex">
+                  <div className="w-1/4 py-2 px-3 text-center border-r border-gray-300 font-semibold">합계 (A)</div>
+                  <div className="w-3/4 text-right py-2 px-3 font-semibold">{totalAmount.toLocaleString()}</div>
+                </div>
+              </div>
+            </div>
+            
+            <div className="mt-4">
+              <div className="flex">
+                <div className="w-1/2 border border-gray-300">
+                  <div className="flex">
+                    <div className="w-1/2 py-2 px-3 text-center font-semibold border-r border-gray-300">공제액 (수수료 * 8%) (B)</div>
+                    <div className="w-1/2 text-right py-2 px-3 font-semibold">{commissionAmount.toLocaleString()}</div>
+                  </div>
+                </div>
+              </div>
+              
+              <div className="flex mt-2">
+                <div className="w-1/2 border border-gray-300 bg-yellow-100">
+                  <div className="flex">
+                    <div className="w-1/2 py-2 px-3 text-center font-semibold border-r border-gray-300">실급정산서<br/>발행금액</div>
+                    <div className="w-1/2 text-right py-2 px-3 font-semibold">{(totalAmount - commissionAmount).toLocaleString()}</div>
+                  </div>
+                  <div className="flex border-t border-gray-300">
+                    <div className="w-1/2 py-2 px-3 text-center border-r border-gray-300">부가세</div>
+                    <div className="w-1/2 text-right py-2 px-3">{vatAmount.toLocaleString()}</div>
+                  </div>
+                  <div className="flex border-t border-gray-300">
+                    <div className="w-1/2 py-2 px-3 text-center font-semibold border-r border-gray-300">합계 (C)</div>
+                    <div className="w-1/2 text-right py-2 px-3 font-semibold">{finalAmount.toLocaleString()}</div>
+                  </div>
+                </div>
+              </div>
+              
+              <div className="flex mt-4">
+                <div className="w-full border border-gray-300">
+                  <div className="flex">
+                    <div className="w-1/2 py-2 px-3 font-semibold border-r border-gray-300">실 지급액 (C-D)</div>
+                    <div className="w-1/2 text-right py-2 px-3 font-semibold bg-yellow-100">{finalAmount.toLocaleString()}</div>
+                  </div>
+                </div>
+              </div>
+              
+              <div className="mt-4 border border-gray-300">
+                <div className="font-semibold bg-gray-100 p-2 border-b border-gray-300">공제내역</div>
+                <div className="divide-y divide-gray-300">
+                  <div className="flex">
+                    <div className="w-1/4 py-2 px-3 border-r border-gray-300">사고금</div>
+                    <div className="w-3/4 text-right py-2 px-3">0</div>
+                  </div>
+                  <div className="flex">
+                    <div className="w-1/4 py-2 px-3 border-r border-gray-300">기름 외</div>
+                    <div className="w-3/4 text-right py-2 px-3">0</div>
+                  </div>
+                  <div className="flex">
+                    <div className="w-1/4 py-2 px-3 border-r border-gray-300">3.3%공제</div>
+                    <div className="w-3/4 text-right py-2 px-3">0</div>
+                  </div>
+                  <div className="flex">
+                    <div className="w-1/4 py-2 px-3 border-r border-gray-300">산재보험</div>
+                    <div className="w-3/4 text-right py-2 px-3">0</div>
+                  </div>
+                  <div className="flex">
+                    <div className="w-1/4 py-2 px-3 border-r border-gray-300">기타</div>
+                    <div className="w-3/4 text-right py-2 px-3">0</div>
+                  </div>
+                  <div className="flex">
+                    <div className="w-1/4 py-2 px-3 text-center font-semibold border-r border-gray-300">합계 (D)</div>
+                    <div className="w-3/4 text-right py-2 px-3 font-semibold">0</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          
+          {/* 정산 항목 상세 */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {/* 마켓컬리 포함 세부내역 */}
+            <div className="border border-gray-300">
+              <div className="text-center bg-orange-200 p-2 font-semibold border-b border-gray-300">[ 컨리 포함 세부내역 ]</div>
+              <table className="w-full">
+                <thead>
+                  <tr className="bg-blue-50 border-b border-gray-300">
+                    <th className="py-1 px-2 text-center border-r border-gray-300">날짜</th>
+                    <th className="py-1 px-2 text-center border-r border-gray-300">조</th>
+                    <th className="py-1 px-2 text-center border-r border-gray-300">차수</th>
+                    <th className="py-1 px-2 text-center">금액</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {kurlySettlements.length > 0 ? (
+                    kurlySettlements.map((settlement) => (
+                      <tr key={settlement.id} className="border-t border-gray-300">
+                        <td className="py-1 px-2 text-center border-r border-gray-300">
+                          {new Date(settlement.delivery_date).toLocaleDateString('ko-KR', { month: 'numeric', day: 'numeric' })}
+                        </td>
+                        <td className="py-1 px-2 text-center border-r border-gray-300">
+                          {settlement.shift || '-'}
+                        </td>
+                        <td className="py-1 px-2 text-center border-r border-gray-300">
+                          {settlement.sequence || '-'}
+                        </td>
+                        <td className="py-1 px-2 text-right">
+                          {settlement.delivery_fee.toLocaleString()}
+                        </td>
+                      </tr>
+                    ))
+                  ) : (
+                    <tr>
+                      <td colSpan={4} className="py-1 px-2 text-center border-t border-gray-300">
+                        - 0
+                      </td>
+                    </tr>
+                  )}
+                  
+                  {kurlySettlements.length > 0 && (
+                    <tr className="bg-blue-50 border-t border-gray-300">
+                      <td colSpan={3} className="py-1 px-2 text-center font-semibold border-r border-gray-300">
+                        합계
+                      </td>
+                      <td className="py-1 px-2 text-right font-semibold">
+                        {kurlyTotal.toLocaleString()}
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+            
+            {/* 쿠팡 포함 세부내역 */}
+            <div className="border border-gray-300">
+              <div className="text-center bg-orange-200 p-2 font-semibold border-b border-gray-300">[ 쿠팡 포함 세부내역 ]</div>
+              <table className="w-full">
+                <thead>
+                  <tr className="bg-blue-50 border-b border-gray-300">
+                    <th className="py-1 px-2 text-center border-r border-gray-300">날짜</th>
+                    <th className="py-1 px-2 text-center border-r border-gray-300">배송구역</th>
+                    <th className="py-1 px-2 text-center border-r border-gray-300">건수</th>
+                    <th className="py-1 px-2 text-center border-r border-gray-300">단가</th>
+                    <th className="py-1 px-2 text-center">금액</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {coupangSettlements.length > 0 ? (
+                    coupangSettlements.map((settlement) => (
+                      <tr key={settlement.id} className="border-t border-gray-300">
+                        <td className="py-1 px-2 text-center border-r border-gray-300">
+                          {new Date(settlement.delivery_date).toLocaleDateString('ko-KR', { month: 'numeric', day: 'numeric' })}
+                        </td>
+                        <td className="py-1 px-2 text-center border-r border-gray-300">
+                          {settlement.delivery_code || '-'}
+                        </td>
+                        <td className="py-1 px-2 text-center border-r border-gray-300">
+                          {settlement.delivery_count || settlement.weight || '-'}
+                        </td>
+                        <td className="py-1 px-2 text-center border-r border-gray-300">
+                          {settlement.unit_price ? settlement.unit_price.toLocaleString() : '-'}
+                        </td>
+                        <td className="py-1 px-2 text-right">
+                          {settlement.delivery_fee.toLocaleString()}
+                        </td>
+                      </tr>
+                    ))
+                  ) : (
+                    <tr>
+                      <td colSpan={5} className="py-1 px-2 text-center border-t border-gray-300">
+                        정산 항목이 없습니다.
+                      </td>
+                    </tr>
+                  )}
+                  
+                  {coupangSettlements.length > 0 && (
+                    <tr className="bg-blue-50 border-t border-gray-300">
+                      <td colSpan={4} className="py-1 px-2 text-center font-semibold border-r border-gray-300">
+                        합계
+                      </td>
+                      <td className="py-1 px-2 text-right font-semibold">
+                        {coupangTotal.toLocaleString()}
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+          
+          {/* 주의사항 */}
+          <div className="mt-8">
+            <div className="text-sm">
+              <div className="font-semibold">※ 공지사항 ※</div>
+              <div>- 공제내역(사고건, 산재보험 등)은 정산금액에서 자동공제됩니다.</div>
+              <div>- 주차 최종 정산금액 변경은 제공후 재공지 예정</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/settlements/reports/page.tsx
+++ b/src/app/dashboard/settlements/reports/page.tsx
@@ -1,0 +1,198 @@
+// src/app/dashboard/settlements/reports/page.tsx
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { getCurrentUser } from '@/lib/auth';
+import { getCouriers } from '@/lib/couriers';
+import Link from 'next/link';
+import toast from 'react-hot-toast';
+import { FiFileText, FiSearch, FiArrowLeft } from 'react-icons/fi';
+
+export default function SettlementReportsPage() {
+  const router = useRouter();
+  const [user, setUser] = useState<any>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [couriers, setCouriers] = useState<any[]>([]);
+  
+  // Form state
+  const today = new Date();
+  const firstDayOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+  const lastDayOfMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+  
+  const [selectedCourier, setSelectedCourier] = useState('');
+  const [startDate, setStartDate] = useState(firstDayOfMonth.toISOString().split('T')[0]);
+  const [endDate, setEndDate] = useState(lastDayOfMonth.toISOString().split('T')[0]);
+
+  useEffect(() => {
+    async function loadData() {
+      try {
+        // Get current user
+        const { user } = await getCurrentUser();
+        if (!user) {
+          toast.error('로그인이 필요합니다.');
+          router.push('/login');
+          return;
+        }
+        
+        setUser(user);
+        
+        if (user.role === 'admin') {
+          // Load all couriers for admin
+          const couriersData = await getCouriers();
+          setCouriers(couriersData);
+        } else {
+          // Set current user as the only courier
+          setCouriers([user]);
+          setSelectedCourier(user.id);
+        }
+        
+        setIsLoading(false);
+      } catch (error) {
+        console.error('Error loading data:', error);
+        toast.error('데이터를 불러오는데 실패했습니다.');
+        setIsLoading(false);
+      }
+    }
+    
+    loadData();
+  }, [router]);
+  
+  function handleGenerateReport() {
+    if (!selectedCourier) {
+      toast.error('기사를 선택해주세요.');
+      return;
+    }
+    
+    const params = new URLSearchParams({
+      courier_id: selectedCourier,
+      start_date: startDate,
+      end_date: endDate
+    });
+    
+    router.push(`/dashboard/settlements/report?${params.toString()}`);
+  }
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-primary-500"></div>
+      </div>
+    );
+  }
+  
+  const isAdmin = user?.role === 'admin';
+  
+  return (
+    <div className="py-6">
+      <div className="flex justify-between items-center mb-6">
+        <div className="flex items-center">
+          <Link href="/dashboard/settlements" className="mr-4 text-secondary-600 hover:text-secondary-800">
+            <FiArrowLeft size={20} />
+          </Link>
+          <h2 className="text-2xl font-semibold text-secondary-800">정산서 생성</h2>
+        </div>
+      </div>
+      
+      <div className="card mb-6">
+        <div className="card-header">
+          <h3 className="text-lg font-semibold text-secondary-800">정산 기간 및 기사 선택</h3>
+        </div>
+        <div className="card-body">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {isAdmin && (
+              <div>
+                <label htmlFor="courier" className="form-label">기사</label>
+                <select
+                  id="courier"
+                  className="form-select"
+                  value={selectedCourier}
+                  onChange={(e) => setSelectedCourier(e.target.value)}
+                  required
+                >
+                  <option value="">기사 선택</option>
+                  {couriers.map((courier) => (
+                    <option key={courier.id} value={courier.id}>{courier.name}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+            
+            <div>
+              <label htmlFor="startDate" className="form-label">시작일</label>
+              <input
+                type="date"
+                id="startDate"
+                className="form-input"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+                required
+              />
+            </div>
+            
+            <div>
+              <label htmlFor="endDate" className="form-label">종료일</label>
+              <input
+                type="date"
+                id="endDate"
+                className="form-input"
+                value={endDate}
+                onChange={(e) => setEndDate(e.target.value)}
+                required
+              />
+            </div>
+          </div>
+          
+          <div className="mt-4">
+            <button
+              type="button"
+              className="btn-primary"
+              onClick={handleGenerateReport}
+            >
+              <FiFileText className="mr-2" />
+              정산서 생성
+            </button>
+          </div>
+        </div>
+      </div>
+      
+      <div className="card">
+        <div className="card-header">
+          <h3 className="text-lg font-semibold text-secondary-800">정산서 안내</h3>
+        </div>
+        <div className="card-body">
+          <div className="space-y-4">
+            <div>
+              <h4 className="font-medium text-secondary-800">정산서 생성 방법</h4>
+              <p className="text-secondary-600 mt-1">
+                1. 정산 기간을 선택합니다. (기본: 현재 월)
+                <br />
+                2. {isAdmin ? '기사를 선택합니다.' : '선택된 기사: ' + user?.name}
+                <br />
+                3. '정산서 생성' 버튼을 클릭합니다.
+              </p>
+            </div>
+            
+            <div>
+              <h4 className="font-medium text-secondary-800">정산서 사용 방법</h4>
+              <p className="text-secondary-600 mt-1">
+                1. 생성된 정산서는 인쇄하거나 PDF로 다운로드할 수 있습니다.
+                <br />
+                2. 정산서에는 마켓컬리, 쿠팡 등 배송 업체별 정산 내역이 포함됩니다.
+                <br />
+                3. 수수료와 부가세가 자동으로 계산됩니다.
+              </p>
+            </div>
+            
+            <div className="p-3 bg-blue-50 text-blue-800 rounded-md">
+              <h4 className="font-medium">참고사항</h4>
+              <p className="text-sm mt-1">
+                정산서는 선택한 기간 내의 입력된 정산 항목을 기준으로 생성됩니다. 정확한 정산서를 위해 배송 정산 항목이 모두 등록되었는지 확인해주세요.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settlements/BatchSettlementForm.tsx
+++ b/src/components/settlements/BatchSettlementForm.tsx
@@ -1,0 +1,454 @@
+// src/components/settlements/BatchSettlementForm.tsx
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { getCouriers } from '@/lib/couriers';
+import { createBatchKurlySettlements, createBatchCoupangSettlements } from '@/lib/settlements';
+import { getCurrentUser } from '@/lib/auth';
+import { useRouter } from 'next/navigation';
+import toast from 'react-hot-toast';
+import { FiPlus, FiX, FiSave } from 'react-icons/fi';
+
+type BatchKurlyItem = {
+  courier_id: string;
+  delivery_date: string;
+  shift: string;
+  sequence: string;
+  delivery_fee: number;
+};
+
+type BatchCoupangItem = {
+  courier_id: string;
+  delivery_date: string;
+  delivery_code: string;
+  delivery_count: number;
+  unit_price: number;
+  delivery_fee: number;
+  weight?: number | null;
+};
+
+type BatchSettlementFormProps = {
+  type: 'kurly' | 'coupang';
+  onSuccess?: () => void;
+};
+
+export default function BatchSettlementForm({ type, onSuccess }: BatchSettlementFormProps) {
+  const router = useRouter();
+  const [couriers, setCouriers] = useState<any[]>([]);
+  const [selectedCourier, setSelectedCourier] = useState('');
+  const [batchDate, setBatchDate] = useState(new Date().toISOString().split('T')[0]);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  
+  // Kurly specific state
+  const [kurlyItems, setKurlyItems] = useState<BatchKurlyItem[]>([]);
+  
+  // Coupang specific state
+  const [coupangItems, setCoupangItems] = useState<BatchCoupangItem[]>([]);
+  
+  useEffect(() => {
+    async function loadData() {
+      try {
+        // Check user permissions
+        const { user } = await getCurrentUser();
+        if (!user) {
+          toast.error('로그인이 필요합니다.');
+          router.push('/login');
+          return;
+        }
+        
+        setIsAdmin(user.role === 'admin');
+        
+        // Load couriers (admin only)
+        if (user.role === 'admin') {
+          const couriersData = await getCouriers();
+          setCouriers(couriersData);
+        } else {
+          // Set current user as the courier
+          setSelectedCourier(user.id);
+        }
+        
+        setIsLoading(false);
+      } catch (error) {
+        console.error('Error loading data:', error);
+        toast.error('데이터를 불러오는데 실패했습니다.');
+        setIsLoading(false);
+      }
+    }
+    
+    loadData();
+  }, [router]);
+  
+  function addKurlyItem() {
+    if (!selectedCourier) {
+      toast.error('기사를 선택해주세요.');
+      return;
+    }
+    
+    const newItem: BatchKurlyItem = {
+      courier_id: selectedCourier,
+      delivery_date: batchDate,
+      shift: '',
+      sequence: '',
+      delivery_fee: 0
+    };
+    
+    setKurlyItems(prev => [...prev, newItem]);
+  }
+  
+  function updateKurlyItem(index: number, field: keyof BatchKurlyItem, value: any) {
+    setKurlyItems(prev => {
+      const updated = [...prev];
+      updated[index] = { ...updated[index], [field]: value };
+      return updated;
+    });
+  }
+  
+  function removeKurlyItem(index: number) {
+    setKurlyItems(prev => prev.filter((_, i) => i !== index));
+  }
+  
+  function addCoupangItem() {
+    if (!selectedCourier) {
+      toast.error('기사를 선택해주세요.');
+      return;
+    }
+    
+    const newItem: BatchCoupangItem = {
+      courier_id: selectedCourier,
+      delivery_date: batchDate,
+      delivery_code: '',
+      delivery_count: 0,
+      unit_price: 1200, // Default unit price
+      delivery_fee: 0,
+      weight: null
+    };
+    
+    setCoupangItems(prev => [...prev, newItem]);
+  }
+  
+  function updateCoupangItem(index: number, field: keyof BatchCoupangItem, value: any) {
+    setCoupangItems(prev => {
+      const updated = [...prev];
+      updated[index] = { ...updated[index], [field]: value };
+      
+      // Auto-calculate delivery fee based on delivery count and unit price
+      if (field === 'delivery_count' || field === 'unit_price') {
+        const count = field === 'delivery_count' ? value : updated[index].delivery_count;
+        const price = field === 'unit_price' ? value : updated[index].unit_price;
+        updated[index].delivery_fee = count * price;
+      }
+      
+      return updated;
+    });
+  }
+  
+  function removeCoupangItem(index: number) {
+    setCoupangItems(prev => prev.filter((_, i) => i !== index));
+  }
+  
+  async function handleSubmitKurly() {
+    if (kurlyItems.length === 0) {
+      toast.error('추가할 항목이 없습니다.');
+      return;
+    }
+    
+    try {
+      setIsSaving(true);
+      
+      // Validate items
+      const hasInvalidItems = kurlyItems.some(item => !item.shift || !item.sequence || !item.delivery_fee);
+      if (hasInvalidItems) {
+        toast.error('모든 항목을 입력해주세요.');
+        setIsSaving(false);
+        return;
+      }
+      
+      // Create items
+      await createBatchKurlySettlements(kurlyItems);
+      
+      toast.success(`${kurlyItems.length}개의 정산 항목이 추가되었습니다.`);
+      setKurlyItems([]);
+      
+      if (onSuccess) {
+        onSuccess();
+      }
+    } catch (error) {
+      console.error('Error saving Kurly settlements:', error);
+      toast.error('정산 항목 저장에 실패했습니다.');
+    } finally {
+      setIsSaving(false);
+    }
+  }
+  
+  async function handleSubmitCoupang() {
+    if (coupangItems.length === 0) {
+      toast.error('추가할 항목이 없습니다.');
+      return;
+    }
+    
+    try {
+      setIsSaving(true);
+      
+      // Validate items
+      const hasInvalidItems = coupangItems.some(item => !item.delivery_code || !item.delivery_count || !item.delivery_fee);
+      if (hasInvalidItems) {
+        toast.error('모든 항목을 입력해주세요.');
+        setIsSaving(false);
+        return;
+      }
+      
+      // Create items
+      await createBatchCoupangSettlements(coupangItems);
+      
+      toast.success(`${coupangItems.length}개의 정산 항목이 추가되었습니다.`);
+      setCoupangItems([]);
+      
+      if (onSuccess) {
+        onSuccess();
+      }
+    } catch (error) {
+      console.error('Error saving Coupang settlements:', error);
+      toast.error('정산 항목 저장에 실패했습니다.');
+    } finally {
+      setIsSaving(false);
+    }
+  }
+  
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center p-6">
+        <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary-500"></div>
+      </div>
+    );
+  }
+  
+  return (
+    <div className="space-y-6">
+      <div className="space-y-4">
+        <div className="flex flex-wrap gap-4">
+          {isAdmin && (
+            <div className="w-full sm:w-auto flex-1">
+              <label htmlFor="courier" className="form-label">기사</label>
+              <select
+                id="courier"
+                className="form-select"
+                value={selectedCourier}
+                onChange={(e) => setSelectedCourier(e.target.value)}
+                required
+              >
+                <option value="">기사 선택</option>
+                {couriers.map((courier) => (
+                  <option key={courier.id} value={courier.id}>{courier.name}</option>
+                ))}
+              </select>
+            </div>
+          )}
+          
+          <div className="w-full sm:w-auto flex-1">
+            <label htmlFor="date" className="form-label">배송일</label>
+            <input
+              type="date"
+              id="date"
+              className="form-input"
+              value={batchDate}
+              onChange={(e) => setBatchDate(e.target.value)}
+              required
+            />
+          </div>
+        </div>
+        
+        <button 
+          type="button" 
+          className="btn-secondary w-full"
+          onClick={type === 'kurly' ? addKurlyItem : addCoupangItem}
+        >
+          <FiPlus className="mr-2" />
+          {type === 'kurly' ? '마켓컬리 항목 추가' : '쿠팡 항목 추가'}
+        </button>
+      </div>
+      
+      {type === 'kurly' && (
+        <div className="space-y-4">
+          {kurlyItems.length > 0 ? (
+            <>
+              <div className="space-y-4">
+                {kurlyItems.map((item, index) => (
+                  <div key={index} className="border rounded p-3 relative">
+                    <button
+                      type="button"
+                      className="absolute top-2 right-2 text-red-500 hover:text-red-700"
+                      onClick={() => removeKurlyItem(index)}
+                    >
+                      <FiX />
+                    </button>
+                    
+                    <div className="grid grid-cols-2 gap-2">
+                      <div>
+                        <label className="text-xs text-secondary-600">조</label>
+                        <input
+                          type="text"
+                          className="form-input mt-1"
+                          value={item.shift}
+                          onChange={(e) => updateKurlyItem(index, 'shift', e.target.value)}
+                          required
+                        />
+                      </div>
+                      
+                      <div>
+                        <label className="text-xs text-secondary-600">차수</label>
+                        <input
+                          type="text"
+                          className="form-input mt-1"
+                          value={item.sequence}
+                          onChange={(e) => updateKurlyItem(index, 'sequence', e.target.value)}
+                          required
+                        />
+                      </div>
+                      
+                      <div className="col-span-2">
+                        <label className="text-xs text-secondary-600">배송비</label>
+                        <input
+                          type="number"
+                          className="form-input mt-1"
+                          value={item.delivery_fee}
+                          onChange={(e) => updateKurlyItem(index, 'delivery_fee', parseInt(e.target.value))}
+                          required
+                        />
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              
+              <button 
+                type="button" 
+                className="btn-primary w-full"
+                onClick={handleSubmitKurly}
+                disabled={isSaving}
+              >
+                {isSaving ? (
+                  <span className="flex items-center justify-center">
+                    <span className="animate-spin rounded-full h-4 w-4 border-t-2 border-b-2 border-white mr-2"></span>
+                    저장 중...
+                  </span>
+                ) : (
+                  <span className="flex items-center justify-center">
+                    <FiSave className="mr-2" />
+                    {kurlyItems.length}개 항목 저장
+                  </span>
+                )}
+              </button>
+            </>
+          ) : (
+            <div className="text-center text-secondary-500 py-6">
+              마켓컬리 정산 항목을 추가해주세요.
+            </div>
+          )}
+        </div>
+      )}
+      
+      {type === 'coupang' && (
+        <div className="space-y-4">
+          {coupangItems.length > 0 ? (
+            <>
+              <div className="space-y-4">
+                {coupangItems.map((item, index) => (
+                  <div key={index} className="border rounded p-3 relative">
+                    <button
+                      type="button"
+                      className="absolute top-2 right-2 text-red-500 hover:text-red-700"
+                      onClick={() => removeCoupangItem(index)}
+                    >
+                      <FiX />
+                    </button>
+                    
+                    <div className="grid grid-cols-2 gap-2">
+                      <div>
+                        <label className="text-xs text-secondary-600">배송 코드</label>
+                        <input
+                          type="text"
+                          className="form-input mt-1"
+                          value={item.delivery_code}
+                          onChange={(e) => updateCoupangItem(index, 'delivery_code', e.target.value)}
+                          required
+                        />
+                      </div>
+                      
+                      <div>
+                        <label className="text-xs text-secondary-600">중량 (kg)</label>
+                        <input
+                          type="number"
+                          step="0.1"
+                          className="form-input mt-1"
+                          value={item.weight || ''}
+                          onChange={(e) => updateCoupangItem(index, 'weight', e.target.value ? parseFloat(e.target.value) : null)}
+                        />
+                      </div>
+                      
+                      <div>
+                        <label className="text-xs text-secondary-600">배송 건수</label>
+                        <input
+                          type="number"
+                          className="form-input mt-1"
+                          value={item.delivery_count}
+                          onChange={(e) => updateCoupangItem(index, 'delivery_count', parseInt(e.target.value))}
+                          required
+                        />
+                      </div>
+                      
+                      <div>
+                        <label className="text-xs text-secondary-600">건당 단가</label>
+                        <input
+                          type="number"
+                          className="form-input mt-1"
+                          value={item.unit_price}
+                          onChange={(e) => updateCoupangItem(index, 'unit_price', parseInt(e.target.value))}
+                          required
+                        />
+                      </div>
+                      
+                      <div className="col-span-2">
+                        <label className="text-xs text-secondary-600">배송비 (자동 계산됨)</label>
+                        <input
+                          type="number"
+                          className="form-input mt-1 bg-secondary-50"
+                          value={item.delivery_fee}
+                          readOnly
+                        />
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              
+              <button 
+                type="button" 
+                className="btn-primary w-full"
+                onClick={handleSubmitCoupang}
+                disabled={isSaving}
+              >
+                {isSaving ? (
+                  <span className="flex items-center justify-center">
+                    <span className="animate-spin rounded-full h-4 w-4 border-t-2 border-b-2 border-white mr-2"></span>
+                    저장 중...
+                  </span>
+                ) : (
+                  <span className="flex items-center justify-center">
+                    <FiSave className="mr-2" />
+                    {coupangItems.length}개 항목 저장
+                  </span>
+                )}
+              </button>
+            </>
+          ) : (
+            <div className="text-center text-secondary-500 py-6">
+              쿠팡 정산 항목을 추가해주세요.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/couriers.ts
+++ b/src/lib/couriers.ts
@@ -1,260 +1,75 @@
-import { supabase, User } from './supabase';
+// src/lib/couriers.ts
+import { createClient } from '@/lib/supabase';
 
-// 모든 택배기사 가져오기
-export async function getAllCouriers() {
+export type Courier = {
+  id: string;
+  name: string;
+  phone: string;
+  email?: string;
+  role: string;
+};
+
+// Get all couriers (renamed from getAllCouriers to getCouriers for compatibility)
+export async function getCouriers() {
+  const supabase = createClient();
+  
   const { data, error } = await supabase
     .from('users')
     .select('*')
     .eq('role', 'courier')
     .order('name');
-
+    
   if (error) {
     console.error('Error fetching couriers:', error);
     throw error;
   }
-
-  return data as User[];
+  
+  return data as Courier[];
 }
 
-// 특정 택배기사 정보 가져오기
-export async function getCourier(id: string) {
+// Get courier by ID (renamed from getCourier to getCourierById for compatibility)
+export async function getCourierById(courierId: string) {
+  const supabase = createClient();
+  
   const { data, error } = await supabase
     .from('users')
     .select('*')
-    .eq('id', id)
-    .eq('role', 'courier')
+    .eq('id', courierId)
     .single();
-
+    
   if (error) {
-    console.error(`Error fetching courier with id ${id}:`, error);
+    console.error('Error fetching courier:', error);
     throw error;
   }
-
-  return data as User;
+  
+  return data as Courier;
 }
 
-// 근무 가능한 택배기사 가져오기
-export async function getAvailableCouriers(date: string) {
-  const { data, error } = await supabase
-    .from('votes')
-    .select('*, users:courier_id(*)')
-    .eq('date', date)
-    .eq('is_available', true);
-
-  if (error) {
-    console.error(`Error fetching available couriers for date ${date}:`, error);
-    throw error;
-  }
-
-  // 사용자 정보만 추출
-  return data.map(vote => vote.users as User);
+// Keep original function for backward compatibility
+export async function getCourier(courierId: string) {
+  return getCourierById(courierId);
 }
 
-// 특정 날짜의 모든 택배기사 정보 (투표 상태 포함)
-export async function getAllCouriersWithVoteStatus(date: string) {
-  // 1. 모든 택배기사 가져오기
-  const { data: couriers, error: courierError } = await supabase
-    .from('users')
-    .select('*')
-    .eq('role', 'courier')
-    .order('name');
-
-  if (courierError) {
-    console.error('Error fetching all couriers:', courierError);
-    throw courierError;
-  }
-
-  // 2. 해당 날짜의 모든 투표 가져오기
-  const { data: votes, error: voteError } = await supabase
-    .from('votes')
-    .select('*')
-    .eq('date', date);
-
-  if (voteError) {
-    console.error(`Error fetching votes for date ${date}:`, voteError);
-    throw voteError;
-  }
-
-  // 3. 투표 정보 매핑
-  const voteMap = new Map();
-  votes.forEach(vote => {
-    voteMap.set(vote.courier_id, vote.is_available);
-  });
-
-  // 4. 각 기사에 투표 상태 추가
-  const couriersWithVoteStatus = couriers.map(courier => ({
-    ...courier,
-    vote_status: voteMap.has(courier.id)
-      ? (voteMap.get(courier.id) ? 'available' : 'unavailable')
-      : 'not_voted'
-  }));
-
-  return couriersWithVoteStatus;
+// Get all couriers (original function)
+export async function getAllCouriers() {
+  return getCouriers();
 }
 
-// 이미 배치된 택배기사 가져오기
-export async function getAssignedCouriers(date: string) {
-  const { data, error } = await supabase
-    .from('assignments')
-    .select('courier_id')
-    .eq('date', date);
-
-  if (error) {
-    console.error(`Error fetching assigned couriers for date ${date}:`, error);
-    throw error;
-  }
-
-  return data.map(assignment => assignment.courier_id);
-}
-
-// 택배기사 정보 업데이트하기
-export async function updateCourier(id: string, userData: Partial<User>) {
+// Update courier
+export async function updateCourier(courierId: string, updates: Partial<Courier>) {
+  const supabase = createClient();
+  
   const { data, error } = await supabase
     .from('users')
-    .update(userData)
-    .eq('id', id)
-    .eq('role', 'courier')
+    .update(updates)
+    .eq('id', courierId)
     .select()
     .single();
-
+    
   if (error) {
-    console.error(`Error updating courier with id ${id}:`, error);
+    console.error('Error updating courier:', error);
     throw error;
   }
-
-  return data as User;
-}
-
-// 택배기사 통계 가져오기
-export async function getCourierStats(id: string, fromDate?: string, toDate?: string) {
-  const today = new Date();
-  const startDate = fromDate || new Date(today.getFullYear(), today.getMonth(), 1).toISOString().split('T')[0];
-  const endDate = toDate || today.toISOString().split('T')[0];
-
-  // 총 배치 횟수
-  const { count: totalAssignments, error: countError } = await supabase
-    .from('assignments')
-    .select('*', { count: 'exact', head: true })
-    .eq('courier_id', id)
-    .gte('date', startDate)
-    .lte('date', endDate);
-
-  if (countError) {
-    console.error(`Error getting assignment count for courier ${id}:`, countError);
-    throw countError;
-  }
-
-  // 물류센터별 배치 횟수
-  const { data: centerAssignments, error: centerError } = await supabase
-    .from('assignments')
-    .select(`
-      logistics_center_id,
-      centers:logistics_center_id(name)
-    `)
-    .eq('courier_id', id)
-    .gte('date', startDate)
-    .lte('date', endDate);
-
-  if (centerError) {
-    console.error(`Error getting center assignments for courier ${id}:`, centerError);
-    throw centerError;
-  }
-
-  // 물류센터별 집계
-  const centerStats: Record<string, { centerId: string, centerName: string, count: number }> = {};
-  centerAssignments.forEach(assignment => {
-    const centerId = assignment.logistics_center_id;
-    const centerName = assignment.centers ? assignment.centers[0].name : '알 수 없음';
-
-    if (!centerStats[centerId]) {
-      centerStats[centerId] = {
-        centerId,
-        centerName,
-        count: 0
-      };
-    }
-
-    centerStats[centerId].count++;
-  });
-
-  return {
-    totalAssignments: totalAssignments || 0,
-    centerStats: Object.values(centerStats)
-  };
-}
-
-// 알림 설정 가져오기
-export async function getCourierNotificationSettings(id: string) {
-  const { data, error } = await supabase
-    .from('notification_settings')
-    .select('*')
-    .eq('user_id', id)
-    .single();
-
-  if (error && error.code !== 'PGRST116') { // PGRST116: 결과가 없음
-    console.error(`Error fetching notification settings for courier ${id}:`, error);
-    throw error;
-  }
-
-  return data || {
-    user_id: id,
-    sms_enabled: false,
-    email_enabled: true,
-    kakao_enabled: false
-  };
-}
-
-// 알림 설정 업데이트하기
-export async function updateCourierNotificationSettings(id: string, settings: {
-  sms_enabled?: boolean;
-  email_enabled?: boolean;
-  kakao_enabled?: boolean;
-}) {
-  // 먼저 설정이 있는지 확인
-  const { data: existingSettings, error: fetchError } = await supabase
-    .from('notification_settings')
-    .select('*')
-    .eq('user_id', id)
-    .maybeSingle();
-
-  if (fetchError && fetchError.code !== 'PGRST116') {
-    console.error(`Error checking notification settings for courier ${id}:`, fetchError);
-    throw fetchError;
-  }
-
-  if (existingSettings) {
-    // 기존 설정 업데이트
-    const { data, error } = await supabase
-      .from('notification_settings')
-      .update(settings)
-      .eq('user_id', id)
-      .select()
-      .single();
-
-    if (error) {
-      console.error(`Error updating notification settings for courier ${id}:`, error);
-      throw error;
-    }
-
-    return data;
-  } else {
-    // 새 설정 생성
-    const { data, error } = await supabase
-      .from('notification_settings')
-      .insert([{
-        user_id: id,
-        sms_enabled: settings.sms_enabled ?? false,
-        email_enabled: settings.email_enabled ?? true,
-        kakao_enabled: settings.kakao_enabled ?? false
-      }])
-      .select()
-      .single();
-
-    if (error) {
-      console.error(`Error creating notification settings for courier ${id}:`, error);
-      throw error;
-    }
-
-    return data;
-  }
+  
+  return data as Courier;
 }

--- a/src/lib/settlements.ts
+++ b/src/lib/settlements.ts
@@ -1,0 +1,295 @@
+// src/lib/settlements.ts
+import { createClient } from '@/lib/supabase';
+import { 
+  Settlement, 
+  KurlySettlement, 
+  CoupangSettlement, 
+  SettlementStatement, 
+  SettlementAdjustment 
+} from '@/lib/types/settlement';
+
+// Get all settlements
+export async function getSettlements(startDate?: string, endDate?: string) {
+  const supabase = createClient();
+  
+  let query = supabase
+    .from('settlements')
+    .select(`
+      *,
+      courier:courier_id(name)
+    `)
+    .order('delivery_date', { ascending: false });
+    
+  if (startDate) {
+    query = query.gte('delivery_date', startDate);
+  }
+  
+  if (endDate) {
+    query = query.lte('delivery_date', endDate);
+  }
+  
+  const { data, error } = await query;
+    
+  if (error) {
+    console.error('Error fetching settlements:', error);
+    throw error;
+  }
+  
+  return data as Settlement[];
+}
+
+// Get courier's settlements
+export async function getCourierSettlements(courierId: string, startDate?: string, endDate?: string) {
+  const supabase = createClient();
+  
+  let query = supabase
+    .from('settlements')
+    .select('*')
+    .eq('courier_id', courierId)
+    .order('delivery_date', { ascending: false });
+    
+  if (startDate) {
+    query = query.gte('delivery_date', startDate);
+  }
+  
+  if (endDate) {
+    query = query.lte('delivery_date', endDate);
+  }
+  
+  const { data, error } = await query;
+    
+  if (error) {
+    console.error('Error fetching courier settlements:', error);
+    throw error;
+  }
+  
+  return data as Settlement[];
+}
+
+// Get Kurly settlements
+export async function getKurlySettlements(courierId?: string, startDate?: string, endDate?: string) {
+  const supabase = createClient();
+  
+  let query = supabase
+    .from('kurly_settlements')
+    .select(`
+      *,
+      courier:courier_id(name)
+    `)
+    .order('delivery_date', { ascending: false });
+    
+  if (courierId) {
+    query = query.eq('courier_id', courierId);
+  }
+  
+  if (startDate) {
+    query = query.gte('delivery_date', startDate);
+  }
+  
+  if (endDate) {
+    query = query.lte('delivery_date', endDate);
+  }
+  
+  const { data, error } = await query;
+    
+  if (error) {
+    console.error('Error fetching Kurly settlements:', error);
+    throw error;
+  }
+  
+  return data as KurlySettlement[];
+}
+
+// Get Coupang settlements
+export async function getCoupangSettlements(courierId?: string, startDate?: string, endDate?: string) {
+  const supabase = createClient();
+  
+  let query = supabase
+    .from('coupang_settlements')
+    .select(`
+      *,
+      courier:courier_id(name)
+    `)
+    .order('delivery_date', { ascending: false });
+    
+  if (courierId) {
+    query = query.eq('courier_id', courierId);
+  }
+  
+  if (startDate) {
+    query = query.gte('delivery_date', startDate);
+  }
+  
+  if (endDate) {
+    query = query.lte('delivery_date', endDate);
+  }
+  
+  const { data, error } = await query;
+    
+  if (error) {
+    console.error('Error fetching Coupang settlements:', error);
+    throw error;
+  }
+  
+  return data as CoupangSettlement[];
+}
+
+// Create Kurly settlement
+export async function createKurlySettlement(settlement: Omit<KurlySettlement, 'id' | 'created_at'>) {
+  const supabase = createClient();
+  
+  const { data, error } = await supabase
+    .from('kurly_settlements')
+    .insert([settlement])
+    .select()
+    .single();
+    
+  if (error) {
+    console.error('Error creating Kurly settlement:', error);
+    throw error;
+  }
+  
+  return data as KurlySettlement;
+}
+
+// Create Coupang settlement
+export async function createCoupangSettlement(settlement: Omit<CoupangSettlement, 'id' | 'created_at'>) {
+  const supabase = createClient();
+  
+  const { data, error } = await supabase
+    .from('coupang_settlements')
+    .insert([settlement])
+    .select()
+    .single();
+    
+  if (error) {
+    console.error('Error creating Coupang settlement:', error);
+    throw error;
+  }
+  
+  return data as CoupangSettlement;
+}
+
+// Create batch Kurly settlements
+export async function createBatchKurlySettlements(settlements: Omit<KurlySettlement, 'id' | 'created_at'>[]) {
+  const supabase = createClient();
+  
+  const { data, error } = await supabase
+    .from('kurly_settlements')
+    .insert(settlements)
+    .select();
+    
+  if (error) {
+    console.error('Error creating batch Kurly settlements:', error);
+    throw error;
+  }
+  
+  return data as KurlySettlement[];
+}
+
+// Create batch Coupang settlements
+export async function createBatchCoupangSettlements(settlements: Omit<CoupangSettlement, 'id' | 'created_at'>[]) {
+  const supabase = createClient();
+  
+  const { data, error } = await supabase
+    .from('coupang_settlements')
+    .insert(settlements)
+    .select();
+    
+  if (error) {
+    console.error('Error creating batch Coupang settlements:', error);
+    throw error;
+  }
+  
+  return data as CoupangSettlement[];
+}
+
+// Get settlement statements
+export async function getSettlementStatements(courierId?: string) {
+  const supabase = createClient();
+  
+  let query = supabase
+    .from('settlement_statements')
+    .select(`
+      *,
+      courier:courier_id(name)
+    `)
+    .order('end_date', { ascending: false });
+    
+  if (courierId) {
+    query = query.eq('courier_id', courierId);
+  }
+  
+  const { data, error } = await query;
+    
+  if (error) {
+    console.error('Error fetching settlement statements:', error);
+    throw error;
+  }
+  
+  return data as SettlementStatement[];
+}
+
+// Get settlement statement by ID
+export async function getSettlementStatementById(statementId: string) {
+  const supabase = createClient();
+  
+  const { data, error } = await supabase
+    .from('settlement_statements')
+    .select(`
+      *,
+      courier:courier_id(name),
+      kurly_settlements(*),
+      coupang_settlements(*),
+      adjustments:settlement_adjustments(*)
+    `)
+    .eq('id', statementId)
+    .single();
+    
+  if (error) {
+    console.error('Error fetching settlement statement:', error);
+    throw error;
+  }
+  
+  return data as SettlementStatement;
+}
+
+// Create settlement statement
+export async function createSettlementStatement(
+  statement: Omit<SettlementStatement, 'id' | 'created_at' | 'kurly_settlements' | 'coupang_settlements' | 'adjustments'>
+) {
+  const supabase = createClient();
+  
+  const { data, error } = await supabase
+    .from('settlement_statements')
+    .insert([statement])
+    .select()
+    .single();
+    
+  if (error) {
+    console.error('Error creating settlement statement:', error);
+    throw error;
+  }
+  
+  return data as SettlementStatement;
+}
+
+// Create settlement adjustment
+export async function createSettlementAdjustment(
+  adjustment: Omit<SettlementAdjustment, 'id' | 'created_at'>
+) {
+  const supabase = createClient();
+  
+  const { data, error } = await supabase
+    .from('settlement_adjustments')
+    .insert([adjustment])
+    .select()
+    .single();
+    
+  if (error) {
+    console.error('Error creating settlement adjustment:', error);
+    throw error;
+  }
+  
+  return data as SettlementAdjustment;
+}

--- a/src/lib/types/settlement.ts
+++ b/src/lib/types/settlement.ts
@@ -1,0 +1,53 @@
+// src/lib/types/settlement.ts
+export type Settlement = {
+  id: string;
+  courier_id: string;
+  delivery_date: string;
+  delivery_fee: number;
+  created_at: string;
+  courier?: {
+    name: string;
+  };
+};
+
+export type KurlySettlement = Settlement & {
+  shift?: string;
+  sequence?: string;
+};
+
+export type CoupangSettlement = Settlement & {
+  delivery_code?: string;
+  delivery_count?: number;
+  unit_price?: number;
+  weight?: number | null;
+};
+
+export type SettlementStatement = {
+  id: string;
+  courier_id: string;
+  start_date: string;
+  end_date: string;
+  total_amount: number;
+  commission_rate: number;
+  commission_amount: number;
+  final_amount: number;
+  vat_amount: number;
+  payment_status: 'pending' | 'paid' | 'cancelled';
+  payment_date: string | null;
+  created_at: string;
+  courier?: {
+    name: string;
+  };
+  kurly_settlements?: KurlySettlement[];
+  coupang_settlements?: CoupangSettlement[];
+  adjustments?: SettlementAdjustment[];
+};
+
+export type SettlementAdjustment = {
+  id: string;
+  statement_id: string;
+  description: string;
+  amount: number;
+  type: 'expense' | 'income' | 'tax' | 'other';
+  created_at: string;
+};


### PR DESCRIPTION
## 정산 시스템 구현

이 PR에서는 아래와 같은 기능들이 추가되었습니다:

### 1. 데이터베이스 스키마
- 배송사별 정산 테이블 (kurly_settlements, coupang_settlements)
- 정산서 테이블 (settlement_statements)
- 조정 항목 테이블 (settlement_adjustments)

### 2. 주요 기능 구현
- 기사별/배송사별 정산 항목 관리
- 일괄 등록 기능으로 여러 항목 한번에 처리
- 기간별 정산서 생성 및 출력
- 정산서 인쇄 및 PDF 다운로드 

### 3. 버그 수정
- 기존의 `getCourierById`, `getCouriers` 관련 컴파일 오류 해결

### 4. 화면 구성
- 정산 메인 페이지 (/dashboard/settlements)
- 배송사별 정산 등록 페이지 (마켓컬리, 쿠팡)
- 일괄 등록 페이지 (/dashboard/settlements/batch)
- 정산서 생성 페이지 (/dashboard/settlements/reports)
- 정산서 출력 페이지 (/dashboard/settlements/report) - 정산서 서식 구현

### 5. 주요 파일
- database/migration_settlement_system.sql - 데이터베이스 스키마
- src/lib/couriers.ts - 수정된 기사 관련 API 함수
- src/lib/settlements.ts - 정산 관련 API 함수
- src/lib/types/settlement.ts - 정산 관련 타입 정의
- src/components/settlements/* - 정산 관련 컴포넌트
- src/app/dashboard/settlements/* - 정산 관련 페이지

### 배포 전 작업 사항
1. 데이터베이스 마이그레이션 실행
2. 환경 변수 확인
3. 대시보드 메뉴에 정산 관련 항목 추가

### 테스트 필요 사항
- 일괄 정산 항목 등록 기능
- 정산서 생성 및 출력 기능
- 권한별 접근 제어 (관리자/기사)